### PR TITLE
增加wechat channel “关键词自动接收好友申请”功能和“关键词自动邀请进群”插件

### DIFF
--- a/bridge/reply.py
+++ b/bridge/reply.py
@@ -11,12 +11,13 @@ class ReplyType(Enum):
     VIDEO_URL = 5  # 视频URL
     FILE = 6  # 文件
     CARD = 7  # 微信名片，仅支持ntchat
-    InviteRoom = 8  # 邀请好友进群
+    INVITE_ROOM = 8  # 邀请好友进群
     INFO = 9
     ERROR = 10
     TEXT_ = 11  # 强制文本
     VIDEO = 12
     MINIAPP = 13  # 小程序
+    ACCEPT_FRIEND = 19 # 接受好友申请
 
     def __str__(self):
         return self.name

--- a/channel/wechat/wechat_message.py
+++ b/channel/wechat/wechat_message.py
@@ -59,7 +59,10 @@ class WechatMessage(ChatMessage):
         elif itchat_msg["Type"] == SHARING:
             self.ctype = ContextType.SHARING
             self.content = itchat_msg.get("Url")
-
+        elif itchat_msg["Type"] == FRIENDS:
+            self.ctype = ContextType.ACCEPT_FRIEND
+            self.content = itchat_msg.get("RecommendInfo")
+            
         else:
             raise NotImplementedError("Unsupported message type: Type:{} MsgType:{}".format(itchat_msg["Type"], itchat_msg["MsgType"]))
 

--- a/config-template.json
+++ b/config-template.json
@@ -7,5 +7,6 @@
   "single_chat_prefix": [""],
   "single_chat_reply_prefix": "",
   "group_chat_prefix": ["@bot"],
-  "group_name_white_list": ["ALL_GROUP"]
+  "group_name_white_list": ["ALL_GROUP"],
+  "accept_friend_commands": ["加好友"]
 }

--- a/config.py
+++ b/config.py
@@ -24,6 +24,7 @@ available_setting = {
     "single_chat_prefix": ["bot", "@bot"],  # 私聊时文本需要包含该前缀才能触发机器人回复
     "single_chat_reply_prefix": "[bot] ",  # 私聊时自动回复的前缀，用于区分真人
     "single_chat_reply_suffix": "",  # 私聊时自动回复的后缀，\n 可以换行
+    "accept_friend_commands": ["加好友"],  # 自动接受好友请求的申请信息
     "group_chat_prefix": ["@bot"],  # 群聊时包含该前缀则会触发机器人回复
     "group_chat_reply_prefix": "",  # 群聊时自动回复的前缀
     "group_chat_reply_suffix": "",  # 群聊时自动回复的后缀，\n 可以换行

--- a/plugins/source.json
+++ b/plugins/source.json
@@ -19,6 +19,10 @@
     "Apilot": {
       "url": "https://github.com/6vision/Apilot.git",
       "desc": "通过api直接查询早报、热榜、快递、天气等实用信息的插件"
+    },
+    "GroupInvitation": {
+      "url": "https://github.com/dfldylan/GroupInvitation.git",
+      "desc": "根据特定关键词自动邀请用户加入指定的群聊"
     }
   }
 }


### PR DESCRIPTION
- 配置

插件plugins/group_invitation 插件依赖于 config.json 文件进行配置。请按照以下步骤进行配置：

复制 config.json.template 文件并重命名为 config.json。

在 config.json 文件中，添加您希望机器人响应的关键词和对应的群聊名称。例如：

{
    "群聊": "我的群聊"
}
这意味着当用户发送包含“群聊”这一关键词的消息时，机器人将尝试邀请该用户加入名为“我的群聊”的群组。

- 使用

安装并正确配置插件后，当机器人收到包含特定关键词的消息时，它将自动触发群聊邀请流程。

- 已知问题

如果微信群是需要邀请进群的，就无法直接邀请进群。