### PR TITLE
支持回复图片视频，配置全局禁用插件，增加插件转换微信分享

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ plugins/banwords/lib/__pycache__
 !plugins/linkai
 !plugins/jina_sum
 !plugins/jina_sum/**/
+!plugins/transform_sharing
 client_config.json

--- a/channel/chat_channel.py
+++ b/channel/chat_channel.py
@@ -188,7 +188,7 @@ class ChatChannel(Channel):
         reply = e_context["reply"]
         if not e_context.is_pass():
             logger.debug("[WX] ready to handle context: type={}, content={}".format(context.type, context.content))
-            if context.type == ContextType.TEXT or context.type == ContextType.IMAGE_CREATE:  # 文字和图片消息
+            if context.type in [ContextType.TEXT, ContextType.IMAGE_CREATE, ContextType.SHARING]:  # 文字、分享和图片消息
                 context["channel"] = e_context["channel"]
                 reply = super().build_reply_content(context.content, context)
             elif context.type == ContextType.VOICE:  # 语音消息
@@ -225,8 +225,6 @@ class ChatChannel(Channel):
                 }
             elif context.type == ContextType.ACCEPT_FRIEND:  # 好友申请，匹配字符串
                 reply = self._build_friend_request_reply(context)
-            elif context.type == ContextType.SHARING:  # 分享信息，当前无默认逻辑
-                pass
             elif context.type == ContextType.FUNCTION or context.type == ContextType.FILE:  # 文件消息及函数调用等，当前无默认逻辑
                 pass
             else:

--- a/config.py
+++ b/config.py
@@ -170,6 +170,18 @@ available_setting = {
     "linkai_api_key": "",
     "linkai_app_code": "",
     "linkai_api_base": "https://api.link-ai.chat",  # linkAI服务地址，若国内无法访问或延迟较高可改为 https://api.link-ai.tech
+    # 插件开关
+    "use_jinasum": True,  # 是否使用JinaSum插件
+    "use_godcmd": True,  # 是否使用管理员指令插件
+    "use_finish": True,  # 是否使用未知指令兜底插件
+    "use_dungeon": True, # 是否使用文字冒险插件
+    "use_bdunit": True,  # 是否使用百度UNIT插件
+    "use_banwords": True, # 是否使用敏感词过滤插件
+    "use_hello": True,  # 是否使用入群自动迎新插件
+    "use_keyword": True,  # 是否使用关键词匹配过滤插件
+    "use_role": True,  # 是否使用角色扮演插件
+    "use_tool": True, # 是否使用工具插件,
+    "use_transformsharing": True,  # 是否使用TransformSharing插件
 }
 
 

--- a/plugins/plugin_manager.py
+++ b/plugins/plugin_manager.py
@@ -139,7 +139,11 @@ class PluginManager:
 
     def activate_plugins(self):  # 生成新开启的插件实例
         failed_plugins = []
-        for name, plugincls in self.plugins.items():
+        for name, plugincls in self.plugins.items():            # 如果config中有配置 use_<plugin_name> 的则禁用插件
+            if conf().get("use_" + name.lower(), True) == False:
+                logger.warn("插件 %s 已被禁用" % (name))
+                self.disable_plugin(name)
+                continue
             if plugincls.enabled:
                 if name not in self.instances:
                     try:

--- a/plugins/transform_sharing/__init__.py
+++ b/plugins/transform_sharing/__init__.py
@@ -1,0 +1,2 @@
+from .transform_sharing import *
+

--- a/plugins/transform_sharing/config.json.template
+++ b/plugins/transform_sharing/config.json.template
@@ -1,0 +1,4 @@
+{
+  "white_url_list": [],
+  "black_url_list": ["https://support.weixin.qq.com", "https://channels-aladin.wxqcloud.qq.com"]
+}

--- a/plugins/transform_sharing/transform_sharing.py
+++ b/plugins/transform_sharing/transform_sharing.py
@@ -1,0 +1,95 @@
+# encoding:utf-8
+import json
+import os
+import html
+from urllib.parse import urlparse
+
+import requests
+
+import plugins
+from bridge.context import ContextType
+from bridge.reply import Reply, ReplyType
+from common.log import logger
+from plugins import *
+
+@plugins.register(
+    name="TransformSharing",
+    desire_priority=5,
+    hidden=False,
+    desc="转换分享链接",
+    version="0.0.1",
+    author="gadzan",
+)
+class TransformSharing(Plugin):
+
+    white_url_list = []
+    black_url_list = [
+        "https://support.weixin.qq.com", # 视频号视频
+        "https://channels-aladin.wxqcloud.qq.com", # 视频号音乐
+    ]
+
+    def __init__(self):
+        super().__init__()
+        try:
+            self.config = super().load_config()
+            if not self.config:
+                self.config = self._load_config_template()
+            self.white_url_list = self.config.get("white_url_list", self.white_url_list)
+            self.black_url_list = self.config.get("black_url_list", self.black_url_list)
+            logger.info(f"[TransformSharing] inited, config={self.config}")
+            self.handlers[Event.ON_HANDLE_CONTEXT] = self.on_handle_context
+        except Exception as e:
+            logger.error(f"[TransformSharing] 初始化异常：{e}")
+            raise "[TransformSharing] init failed, ignore "
+
+    def on_handle_context(self, e_context: EventContext):
+        try:
+            context = e_context["context"]
+            content = context.content
+            if context.type != ContextType.SHARING and context.type != ContextType.TEXT:
+                return
+            if not self._check_url(content):
+                logger.debug(f"[TransformSharing] {content} is not a valid url, skip")
+                return
+            logger.debug("[TransformSharing] on_handle_context. content: %s" % content)
+            reply = Reply(ReplyType.TEXT, "🧐正在阅读您的分享，请稍候...")
+            channel = e_context["channel"]
+            channel.send(reply, context)
+
+            target_url = html.unescape(content) # 解决公众号卡片链接校验问题，参考 https://github.com/fatwang2/sum4all/commit/b983c49473fc55f13ba2c44e4d8b226db3517c45
+            context.content = target_url
+            logger.debug(f"[TransformSharing] 转换分享为链接: {context.content}")
+        except Exception as e:
+            logger.exception(f"[TransformSharing] {str(e)}")
+            reply = Reply(ReplyType.ERROR, "我暂时无法处理分享内容，请稍后再试")
+            e_context["reply"] = reply
+            e_context.action = EventAction.BREAK_PASS
+
+    def _load_config_template(self):
+        logger.debug("No plugin config.json, use plugins/transform_sharing/config.json.template")
+        try:
+            plugin_config_path = os.path.join(self.path, "config.json.template")
+            if os.path.exists(plugin_config_path):
+                with open(plugin_config_path, "r", encoding="utf-8") as f:
+                    plugin_conf = json.load(f)
+                    return plugin_conf
+        except Exception as e:
+            logger.exception(e)
+
+    def _check_url(self, target_url: str):
+        stripped_url = target_url.strip()
+        # 简单校验是否是url
+        if not stripped_url.startswith("http://") and not stripped_url.startswith("https://"):
+            return False
+
+        # 检查白名单
+        if len(self.white_url_list):
+            if not any(stripped_url.startswith(white_url) for white_url in self.white_url_list):
+                return False
+
+        # 排除黑名单，黑名单优先级>白名单
+        for black_url in self.black_url_list:
+            if stripped_url.startswith(black_url):
+                return False
+
+        return True


### PR DESCRIPTION
1. 支持回复图片视频
如果是以 http:// 或 https:// 开头，且".jpg", ".jpeg", ".png", ".gif", ".img"结尾，则认为是图片 URL。
如果是以 http:// 或 https:// 开头，且".mp4"结尾，则认为是视频

2. 配置全局禁用插件
支持在全局 config.json 中配置 "use_jinasum": false 以禁用某个插件，use_xxx，xxx为全小写插件名

3. 增加插件转换微信分享
比 JinaSum 优先级低，优先使用 JinaSum, JinaSum 被禁用时，走 TransformSharing 插件，将分享链接提取出来。