### PR TITLE
提高了DSL配置中输入的字符数量限制

### DIFF
--- a/dsl/chat-workflow.yml
+++ b/dsl/chat-workflow.yml
@@ -55,10 +55,10 @@ workflow:
         type: start
         variables:
         - label: query
-          max_length: 256
+          max_length: 999999
           options: []
           required: true
-          type: text-input
+          type: paragraph
           variable: query
       height: 89
       id: '1714264983912'


### PR DESCRIPTION
由于默认的文本字段类型字符限制是256，无法发送长文本
这里修改为“段落”并提高字符限制为999999