### PR TITLE
[Latest]Fix IndexError in _handle_agent by checking for empty message list

### DIFF
--- a/bot/dify/dify_bot.py
+++ b/bot/dify/dify_bot.py
@@ -291,6 +291,9 @@ class DifyBot(Bot):
                 reply = Reply(ReplyType.IMAGE_URL, url)
                 thread = threading.Thread(target=channel.send, args=(reply, context))
                 thread.start()
+        # 检查msgs是否为空
+        if not msgs:
+            return None, "No messages received from agent."
         final_msg = msgs[-1]
         reply = None
         if final_msg['type'] == 'agent_message':


### PR DESCRIPTION
Added a check to ensure the 'msgs' list is not empty before accessing its last element in the '_handle_agent' method. This prevents an 'IndexError' from occurring when the list is empty, ensuring more robust error handling and improving the stability of the bot's response processing.