### PR TITLE
为Gewechat channel添加图片及emoji引用的支持

### DIFF
--- a/bridge/context.py
+++ b/bridge/context.py
@@ -10,6 +10,7 @@ class ContextType(Enum):
     FILE = 4  # 文件信息
     VIDEO = 5  # 视频信息
     SHARING = 6  # 分享信息
+    EMOJI=7  #表情图片
 
     IMAGE_CREATE = 10  # 创建图片命令
     ACCEPT_FRIEND = 19 # 同意好友请求

--- a/channel/gewechat/gewechat_channel.py
+++ b/channel/gewechat/gewechat_channel.py
@@ -130,24 +130,54 @@ class GeWeChatChannel(ChatChannel):
                     logger.error(f"[gewechat] voice file is not mp3, path: {content}, only support mp3")
             except Exception as e:
                 logger.error(f"[gewechat] send voice failed: {e}")
-        elif reply.type == ReplyType.IMAGE_URL:
-            img_url = reply.content
-            self.client.post_image(self.app_id, receiver, img_url)
-            logger.info("[gewechat] sendImage url={}, receiver={}".format(img_url, receiver))
-        elif reply.type == ReplyType.IMAGE:
+        elif reply.type == ReplyType.IMAGE_URL or reply.type == ReplyType.IMAGE:
             image_storage = reply.content
-            image_storage.seek(0)
+            if reply.type == ReplyType.IMAGE_URL:
+                import requests
+                import io
+                img_url = reply.content
+                logger.debug(f"[gewechat]sendImage, download image start, img_url={img_url}")
+                pic_res = requests.get(img_url, stream=True)
+                image_storage = io.BytesIO()
+                size = 0
+                for block in pic_res.iter_content(1024):
+                    size += len(block)
+                    image_storage.write(block)
+                logger.debug(f"[gewechat]sendImage, download image success, size={size}, img_url={img_url}")
+                image_storage.seek(0)
+                if ".webp" in img_url:
+                    try:
+                        from common.utils import convert_webp_to_png
+                        image_storage = convert_webp_to_png(image_storage)
+                    except Exception as e:
+                        logger.error(f"[gewechat]sendImage, failed to convert image: {e}")
+                        return
             # Save image to tmp directory
+            image_storage.seek(0)
+            header = image_storage.read(6)
+            image_storage.seek(0)
             img_data = image_storage.read()
-            img_file_name = f"img_{str(uuid.uuid4())}.png"
+            image_storage.seek(0)
+            extension = ".gif" if header.startswith((b'GIF87a', b'GIF89a')) else ".png"
+            img_file_name = f"img_{str(uuid.uuid4())}{extension}"
             img_file_path = TmpDir().path() + img_file_name
             with open(img_file_path, "wb") as f:
                 f.write(img_data)
             # Construct callback URL
             callback_url = conf().get("gewechat_callback_url")
             img_url = callback_url + "?file=" + img_file_path
-            self.client.post_image(self.app_id, receiver, img_url)
-            logger.info("[gewechat] sendImage, receiver={}, url={}".format(receiver, img_url))
+            if extension == ".gif":
+                result = self.client.post_file(self.app_id, receiver, file_url=img_url, file_name=img_file_name)
+                logger.info("[gewechat] sendGifAsFile, receiver={}, file_url={}, file_name={}, result={}".format(
+                    receiver, img_url, img_file_name, result))
+            else:
+                result = self.client.post_image(self.app_id, receiver, img_url)
+                logger.info("[gewechat] sendImage, receiver={}, url={}, result={}".format(receiver, img_url, result))
+            if result.get('ret') == 200:
+                newMsgId = result['data'].get('newMsgId')
+                new_img_file_path = TmpDir().path() + str(newMsgId) + extension
+                os.rename(img_file_path, new_img_file_path)
+                logger.info("[gewechat] sendImage rename to {}".format(new_img_file_path))
 
 class Query:
     def GET(self):

--- a/channel/gewechat/gewechat_message.py
+++ b/channel/gewechat/gewechat_message.py
@@ -432,6 +432,9 @@ class GeWeChatMessage(ChatMessage):
                         logger.error(f"[gewechat] Failed to parse group join XML: {e}")
                         # Fall back to regular content handling
                         pass
+        elif msg_type == 47:
+            self.ctype = ContextType.EMOJI
+            self.content = msg['Data']['Content']['string']
         else:
             raise NotImplementedError("Unsupported message type: Type:{}".format(msg_type))
 


### PR DESCRIPTION
为Gewechat channel添加图片及emoji引用的支持
demo可参考https://github.com/WoodGoose/plugin_ref

具体改动包括：
- 统一图片发送(IMAGE_URL和IMAGE)
- 支持gif作为文件发送(gewe不支持emoji发送)，可用于emoji下载
- 图片对应的文件路径调整为newMsgId相关，方便引用自己发送的图片
- 支持emoji消息的解析