### PR TITLE
微信自建应用时不需要单聊的前导字符

### DIFF
--- a/channel/chat_channel.py
+++ b/channel/chat_channel.py
@@ -143,6 +143,9 @@ class ChatChannel(Channel):
                 match_prefix = check_prefix(content, conf().get("single_chat_prefix", [""]))
                 if match_prefix is not None:  # 判断如果匹配到自定义前缀，则返回过滤掉前缀+空格后的内容
                     content = content.replace(match_prefix, "", 1).strip()
+                elif self.channel_type == 'wechatcom_app':
+                    # todo:企业微信自建应用不需要前导字符
+                    pass
                 elif context["origin_ctype"] == ContextType.VOICE:  # 如果源消息是私聊的语音消息，允许不匹配前缀，放宽条件
                     pass
                 else:


### PR DESCRIPTION
微信自建应用时不需要单聊的前导字符