### PR TITLE
fix: 解决发送语音未配置时self.content为空

### DIFF
--- a/channel/gewechat/gewechat_message.py
+++ b/channel/gewechat/gewechat_message.py
@@ -335,6 +335,7 @@ class GeWeChatMessage(ChatMessage):
             self.content = msg['Data']['Content']['string']
         elif msg_type == 34:  # Voice message
             self.ctype = ContextType.VOICE
+            self.content = msg['Data']['Content']['string']
             if 'ImgBuf' in msg['Data'] and 'buffer' in msg['Data']['ImgBuf'] and msg['Data']['ImgBuf']['buffer']:
                 silk_data = base64.b64decode(msg['Data']['ImgBuf']['buffer'])
                 silk_file_name = f"voice_{str(uuid.uuid4())}.silk"


### PR DESCRIPTION
在gewe中，未配置时发送语音，如果没进这个判断,**self.content**为空，导致下方的正则替换错误
```python 
if 'ImgBuf' in msg['Data'] and 'buffer' in msg['Data']['ImgBuf'] and msg['Data']['ImgBuf']['buffer']:

**这个地方的self.content为空**

  # 如果是群消息，使用正则表达式去掉wxid前缀和@信息
  self.content = re.sub(f'{self.actual_user_id}:\n', '', self.content)  # 去掉wxid前缀   
  self.content = re.sub(r'@[^\u2005]+\u2005', '', self.content)  # 去掉@信息
```