### PR TITLE
Fix “speech_recognition” for channel "gewechat"

### DIFF
--- a/channel/gewechat/gewechat_channel.py
+++ b/channel/gewechat/gewechat_channel.py
@@ -225,6 +225,11 @@ class Query:
             logger.debug(f"[gewechat] ignore non-user message from {gewechat_msg.from_user_id}: {gewechat_msg.content}")
             return "success"
 
+        # 判断是否需要忽略语音消息
+        if gewechat_msg.ctype == ContextType.VOICE:
+            if conf().get("speech_recognition") != True:
+                return "success"
+
         # 忽略来自自己的消息
         if gewechat_msg.my_msg:
             logger.debug(f"[gewechat] ignore message from myself: {gewechat_msg.actual_user_id}: {gewechat_msg.content}")


### PR DESCRIPTION
fix config:speech_recognition for channel "gewechat" 

修复speech_recognition为false时在gewechat channel下不生效的问题