### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ requests>=2.28.2
 chardet>=5.1.0
 Pillow
 pre-commit
-web.py
+web.py-update
 linkai>=0.0.6.0
 cozepy==0.6


### PR DESCRIPTION
cgi模块在python3.13版本中被移除，pypi中的web.py包并不是其github最新版本，使用web.py-update,可以同步到移除cgi版本的webpy,已在py3.13上测试过，运行正常