### PR TITLE
Coze conversation fix

### DIFF
--- a/bot/bytedance/coze_client.py
+++ b/bot/bytedance/coze_client.py
@@ -29,6 +29,9 @@ class CozeClient(object):
             conversation_id=conversation_id,
             additional_messages=additional_messages
         )
+        # ChatPoll 在类型chat里面存储了conversation_id 参考:cozepy.Chat (init.py line 255 )
+        chat_info = chat_poll.chat
+        session.set_conversation_id(chat_info.conversation_id)
         message_list = chat_poll.messages
         for message in message_list:
             logging.debug('got message:', message.content)

--- a/bot/bytedance/coze_session.py
+++ b/bot/bytedance/coze_session.py
@@ -55,9 +55,10 @@ class CozeSession(object):
         if conf().get("coze_conversation_max_messages", 5) <= 0:
             # 当设置的最大消息数小于等于0，则不限制
             return
-        if self.__user_message_counter >= conf().get("coze_conversation_max_messages", 5):
+        # 由于coze策略 list_message 会返回知识库等消息,因此需要拓展默认的最大消息数
+        if self.__user_message_counter >= conf().get("coze_conversation_max_messages", 20):
             self.__user_message_counter = 0
-            # FIXME: coze目前不支持设置历史消息长度，暂时使用超过5条清空会话的策略，缺点是没有滑动窗口，会突然丢失历史消息
+            # FIXME: coze目前不支持设置历史消息长度，暂时使用超过20条清空会话的策略，缺点是没有滑动窗口，会突然丢失历史消息
             self.__conversation_id = ''
 
         self.__user_message_counter += 1


### PR DESCRIPTION
优化 Coze 对话中 conversation_id 的获取与传递：

新增获取 Coze 返回的 chat.conversation_id，并作为下一条消息的上下文。
注意事项：
对话开始时传入上一会话的 conversation_id，仍会返回新的 conversation_id。
每次对话开始只能传入一个 conversation_id，当前 session 仅保留上一对话的 ID 作为上下文。
参考：[Coze 接口文档 - 响应示例](https://www.coze.cn/open/docs/developer_guides/chat_v3#70a1d1bd)