### PR TITLE
修正CozeBot获取历史会话的行为 CozeBot conversation fix

### DIFF
--- a/bot/bytedance/bytedance_coze_bot.py
+++ b/bot/bytedance/bytedance_coze_bot.py
@@ -229,6 +229,7 @@ class ByteDanceCozeBot(Bot):
         if err is not None:
             logger.error("[COZE] reply error={}".format(err))
             return Reply(ReplyType.ERROR, "我暂时遇到了一些问题，请您稍后重试~")
+        session.add_reply(answer)
         logger.debug(
             "[COZE] new_query={}, session_id={}, reply_cont={}, completion_tokens={}".format(
                 session.messages,

--- a/bot/bytedance/coze_client.py
+++ b/bot/bytedance/coze_client.py
@@ -29,6 +29,9 @@ class CozeClient(object):
             conversation_id=conversation_id,
             additional_messages=additional_messages
         )
+        # ChatPoll 在类型chat里面存储了conversation_id 参考:cozepy.Chat (init.py line 255 )
+        chat_info = chat_poll.chat
+        session.set_conversation_id(chat_info.conversation_id)
         message_list = chat_poll.messages
         for message in message_list:
             logging.debug('got message:', message.content)

--- a/bot/bytedance/coze_client.py
+++ b/bot/bytedance/coze_client.py
@@ -21,8 +21,13 @@ class CozeClient(object):
     def _send_chat(self, bot_id: str,
                    user_id: str, additional_messages: List[Message], session: CozeSession):
         conversation_id = None
+        # 查看目前回话信息是否过多
+        session.count_user_message()
         if session.get_conversation_id() is not None:
             conversation_id = session.get_conversation_id()
+            # 如果session信息没有超出上限，加入至额外信息
+            additional_messages = session.messages + additional_messages
+
         chat_poll = self.coze.chat.create_and_poll(
             bot_id=bot_id,
             user_id=user_id,

--- a/bot/bytedance/coze_client.py
+++ b/bot/bytedance/coze_client.py
@@ -26,7 +26,13 @@ class CozeClient(object):
         if session.get_conversation_id() is not None:
             conversation_id = session.get_conversation_id()
             # 如果session信息没有超出上限，加入至额外信息
-            additional_messages = session.messages + additional_messages
+            for message in session.messages:
+                additional_messages.insert(
+                    0,
+                    Message.build_assistant_answer(message["content"])
+                    if message.get("role") == "assistant"
+                    else Message.build_user_question_text(message["content"]),
+                )
 
         chat_poll = self.coze.chat.create_and_poll(
             bot_id=bot_id,

--- a/bot/bytedance/coze_session.py
+++ b/bot/bytedance/coze_session.py
@@ -55,9 +55,10 @@ class CozeSession(object):
         if conf().get("coze_conversation_max_messages", 5) <= 0:
             # 当设置的最大消息数小于等于0，则不限制
             return
-        if self.__user_message_counter >= conf().get("coze_conversation_max_messages", 5):
+        # 由于coze策略 list_message 会返回知识库等消息,因此需要拓展默认的最大消息数
+        if self.__user_message_counter >= conf().get("coze_conversation_max_messages", 20):
             self.__user_message_counter = 0
-            # FIXME: coze目前不支持设置历史消息长度，暂时使用超过5条清空会话的策略，缺点是没有滑动窗口，会突然丢失历史消息
+            # FIXME: coze目前不支持设置历史消息长度，暂时使用超过20条清空会话的策略，缺点是没有滑动窗口，会突然丢失历史消息
             self.__conversation_id = ''
 
         self.__user_message_counter += 1

--- a/config.py
+++ b/config.py
@@ -112,6 +112,7 @@ available_setting = {
     "coze_api_key": "xxx",
     "coze_bot_id": "xxx",
     "coze_return_show_img": "false",
+    "coze_conversation_max_messages" : 20, # coze目前不支持设置历史消息长度，暂时使用超过最大消息数清空会话的策略，缺点是没有滑动窗口，会突然丢失历史消息
     # wework的通用配置
     "wework_smart": True,  # 配置wework是否使用已登录的企业微信，False为多开
     # 语音设置

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ Pillow
 pre-commit
 web.py-update
 linkai>=0.0.6.0
-cozepy==0.6
+cozepy==0.13


### PR DESCRIPTION
**优化 Coze 对话中 conversation_id 的获取与传递：**

新增获取 Coze 返回的 chat.conversation_id，并作为下一条消息的上下文。
注意事项：
对话开始时传入上一会话的 conversation_id，仍会返回新的 conversation_id。
每次对话开始只能传入一个 conversation_id，当前 session 仅保留上一对话的 ID 作为上下文。
参考：[Coze 接口文档 - 响应示例](https://www.coze.cn/open/docs/developer_guides/chat_v3#70a1d1bd)

**修正 Coze 读取的配置 coze_conversation_max_messages 没有配置在config.py available_setting 的问题**