### PR TITLE
为gewechat增加dify“不回复”的能力

### DIFF
--- a/channel/gewechat/gewechat_channel.py
+++ b/channel/gewechat/gewechat_channel.py
@@ -109,6 +109,11 @@ class GeWeChatChannel(ChatChannel):
         gewechat_message = context.get("msg")
         if reply.type in [ReplyType.TEXT, ReplyType.ERROR, ReplyType.INFO]:
             reply_text = reply.content
+            
+            # 如果不需要回复
+            if '$NO_REPLY$' in reply_text:
+                return
+                
             ats = ""
             if gewechat_message and gewechat_message.is_group:
                 ats = gewechat_message.actual_user_id


### PR DESCRIPTION
当消息内容包含‘$NO_REPLY$‘时，dow不回复任何消息。

适用于多种情况：
1. 如在dify中进行逻辑分流，当LLM认为此条消息与自己无关时可以不回复
2. dify中使用if分流，将多次对话内容存储，只在最后一次做分流
3. 可以在dify中进行关键词判断，只回复含有关键词的场景