### PR TITLE
更新lcard的自己修改版本保存下来 -- 待其它开源大佬完善的问题：1.qq音乐卡片无法打开 2.药典助手无法直接进入搜索药品关键词首页

### DIFF
--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -18,58 +18,45 @@ class Bridge(object):
             "text_to_voice": conf().get("text_to_voice", "google"),
             "translate": conf().get("translate", "baidu"),
         }
-
-        # 这边取配置的模型
-        bot_type = conf().get("bot_type")
-        if bot_type:
-            self.btype["chat"] = bot_type
-        else:
-            model_type = conf().get("model") or const.GPT35
-            if model_type in ["text-davinci-003"]:
-                self.btype["chat"] = const.OPEN_AI
-            if conf().get("use_azure_chatgpt", False):
-                self.btype["chat"] = const.CHATGPTONAZURE
-            if model_type in ["wenxin", "wenxin-4"]:
-                self.btype["chat"] = const.BAIDU
-            if model_type in ["xunfei"]:
-                self.btype["chat"] = const.XUNFEI
-            if model_type in [const.QWEN]:
-                self.btype["chat"] = const.QWEN
-            if model_type in [const.QWEN_TURBO, const.QWEN_PLUS, const.QWEN_MAX]:
-                self.btype["chat"] = const.QWEN_DASHSCOPE
-            if model_type and model_type.startswith("gemini"):
-                self.btype["chat"] = const.GEMINI
-            if model_type in [const.DIFY]:
-                self.btype["chat"] = const.DIFY
-            if model_type and model_type.startswith("glm"):
-                self.btype["chat"] = const.ZHIPU_AI
-            if model_type in [const.COZE]:
-                self.btype["chat"] = const.COZE
-            if model_type and model_type.startswith("claude-3"):
-                self.btype["chat"] = const.CLAUDEAPI
-            if model_type and model_type.startswith("deepseek-"):
-                self.btype["chat"] = const.DEEPSEEK
-
-            if model_type in ["claude"]:
-                self.btype["chat"] = const.CLAUDEAI
-
-            if model_type in [const.MOONSHOT, "moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k"]:
-                self.btype["chat"] = const.MOONSHOT
-
-            if model_type in ["abab6.5-chat"]:
-                self.btype["chat"] = const.MiniMax
-            
-            if conf().get("use_linkai") and conf().get("linkai_api_key"):
-                self.btype["chat"] = const.LINKAI
-                if not conf().get("voice_to_text") or conf().get("voice_to_text") in ["openai"]:
-                    self.btype["voice_to_text"] = const.LINKAI
-                if not conf().get("text_to_voice") or conf().get("text_to_voice") in ["openai", const.TTS_1, const.TTS_1_HD]:
-                    self.btype["text_to_voice"] = const.LINKAI
-
+        model_type = conf().get("model") or const.GPT35
+        if model_type in ["text-davinci-003"]:
+            self.btype["chat"] = const.OPEN_AI
+        if conf().get("use_azure_chatgpt", False):
+            self.btype["chat"] = const.CHATGPTONAZURE
+        if model_type in ["wenxin"]:
+            self.btype["chat"] = const.BAIDU
+        if conf().get("use_linkai") and conf().get("linkai_api_key"):
+            self.btype["chat"] = const.LINKAI
+            if not conf().get("voice_to_text") or conf().get("voice_to_text") in ["openai"]:
+                self.btype["voice_to_text"] = const.LINKAI
+            if not conf().get("text_to_voice") or conf().get("text_to_voice") in [const.TTS_1, const.TTS_1_HD]:
+                self.btype["text_to_voice"] = const.LINKAI
+        if model_type in ["xunfei"]:
+            self.btype["chat"] = const.XUNFEI
+        if model_type and model_type.startswith("gemini"):
+            self.btype["chat"] = const.GEMINI
+        if model_type in [const.CLAUDE3]:
+            self.btype["chat"] = const.CLAUDEAPI
+        if model_type in ["deepseek-chat", "deepseek-coder", " DeepSeek-V2"]:
+            self.btype["chat"] = const.DEEPSEEK
+        if model_type in [const.COZE]:
+            self.btype["chat"] = const.COZE
+        if model_type in [const.QWEN]:
+            self.btype["chat"] = const.QWEN
+        if model_type in [const.QWEN_TURBO, const.QWEN_PLUS, const.QWEN_MAX]:
+            self.btype["chat"] = const.QWEN_DASHSCOPE
+        if model_type in [const.ZHIPU_AI]:
+            self.btype["chat"] = const.ZHIPU_AI
+        if model_type in ["moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k"]:
+            self.btype["chat"] = const.MOONSHOT
+        if model_type in ["abab6.5-chat"]:
+            self.btype["chat"] = const.MiniMax
+        if model_type in [const.DIFY]:
+            self.btype["chat"] = const.DIFY
         self.bots = {}
         self.chat_bots = {}
 
-    # 模型对应的接口
+
     def get_bot(self, typename):
         if self.bots.get(typename) is None:
             logger.info("create bot {} for {}".format(self.btype[typename], typename))
@@ -102,6 +89,7 @@ class Bridge(object):
         if self.chat_bots.get(bot_type) is None:
             self.chat_bots[bot_type] = create_bot(bot_type)
         return self.chat_bots.get(bot_type)
+
 
     def reset_bot(self):
         """

--- a/bridge/context.py
+++ b/bridge/context.py
@@ -4,23 +4,32 @@ from enum import Enum
 
 
 class ContextType(Enum):
+
     TEXT = 1  # 文本消息
     VOICE = 2  # 音频消息
     IMAGE = 3  # 图片消息
     FILE = 4  # 文件信息
     VIDEO = 5  # 视频信息
-    SHARING = 6  # 分享信息
+    SHARING = 6  # 分享链接
     EMOJI=7  #表情图片
-
+    QUOTE=8   #引用消息
+    CARD = 9 #微信名片
     IMAGE_CREATE = 10  # 创建图片命令
-    ACCEPT_FRIEND = 19 # 同意好友请求
+    MINIAPP = 11 # 小程序
+    SYSTEM =12 # 系统消息
+    WCPAY = 13 # 微信扫码付
+    XML = 14 # xml卡片(聊天记录,QQ音乐,未知小程序，动画表情，收藏，直播，未知）
+    WECHAT_VIDEO = 15 #视频号
+    MP = 16 #微信公众号文字消息
+    EXIT_GROUP = 18 #踢出群聊
+    LEAVE_GROUP = 19 #主动退出群聊
     JOIN_GROUP = 20  # 加入群聊
     PATPAT = 21  # 拍了拍
     FUNCTION = 22  # 函数调用
-    EXIT_GROUP = 23 #退出
-
-    NON_USER_MSG = 30  # 来自公众号、腾讯游戏、微信团队等非用户账号的消息
-    STATUS_SYNC  = 51   # 微信客户端的状态同步消息，可以忽略 eggs: 打开/退出某个聊天窗口
+    MP_LINK =23  # 公众号推文
+    STATUS_SYNC = 30  # 微信客户端的状态同步消息，可以忽略 eggs: 打开/退出某个聊天窗口
+    NON_USER_MSG = 31  # 非用户消息
+    ACCEPT_FRIEND = 32  # 接受好友请求
 
 
     def __str__(self):
@@ -51,7 +60,7 @@ class Context:
 
     def get(self, key, default=None):
         try:
-            return self.__getitem__(key)
+            return self[key]
         except KeyError:
             return default
 

--- a/bridge/reply.py
+++ b/bridge/reply.py
@@ -4,23 +4,31 @@ from enum import Enum
 
 
 class ReplyType(Enum):
+
     TEXT = 1  # 文本
     VOICE = 2  # 音频文件
     IMAGE = 3  # 图片文件
     IMAGE_URL = 4  # 图片URL
     VIDEO_URL = 5  # 视频URL
     FILE = 6  # 文件
-    CARD = 7  # 微信名片，仅支持ntchat
-    INVITE_ROOM = 8  # 邀请好友进群
-    INFO = 9
-    ERROR = 10
+    CARD = 7  # 微信名片
+    InviteRoom = 8  # 邀请好友进群
+    INFO = 9  #提示信息
+    ERROR = 10  #错误信息
     TEXT_ = 11  # 强制文本
-    VIDEO = 12
+    VIDEO = 12  #视频
     MINIAPP = 13  # 小程序
-    ACCEPT_FRIEND = 19 # 接受好友申请
+    LINK = 14  #链接
+    ACCEPT_FRIEND = 15  # 接受好友请求
+    CALL_UP = 16  #打电话
+    GIF = 17  #动图
+    XML = 18 #卡片
 
     def __str__(self):
         return self.name
+
+    def is_xml_type(self):
+        return self in [ReplyType.CARD, ReplyType.MINIAPP, ReplyType.LINK, ReplyType.XML]
 
 
 class Reply:

--- a/channel/channel/channel.py
+++ b/channel/channel/channel.py
@@ -1,0 +1,44 @@
+"""
+Message sending channel abstract class
+"""
+
+from bridge.bridge import Bridge
+from bridge.context import Context
+from bridge.reply import *
+
+
+class Channel(object):
+    channel_type = ""
+    NOT_SUPPORT_REPLYTYPE = [ReplyType.VOICE, ReplyType.IMAGE]
+
+    def startup(self):
+        """
+        init channel
+        """
+        raise NotImplementedError
+
+    def handle_text(self, msg):
+        """
+        process received msg
+        :param msg: message object
+        """
+        raise NotImplementedError
+
+    # 统一的发送函数，每个Channel自行实现，根据reply的type字段发送不同类型的消息
+    def send(self, reply: Reply, context: Context):
+        """
+        send message to user
+        :param msg: message content
+        :param receiver: receiver channel account
+        :return:
+        """
+        raise NotImplementedError
+
+    def build_reply_content(self, query, context: Context = None) -> Reply:
+        return Bridge().fetch_reply_content(query, context)
+
+    def build_voice_to_text(self, voice_file) -> Reply:
+        return Bridge().fetch_voice_to_text(voice_file)
+
+    def build_text_to_voice(self, text) -> Reply:
+        return Bridge().fetch_text_to_voice(text)

--- a/channel/channel/channel_factory.py
+++ b/channel/channel/channel_factory.py
@@ -1,0 +1,54 @@
+"""
+channel factory
+"""
+from common import const
+from .channel import Channel
+
+
+def create_channel(channel_type) -> Channel:
+    """
+    create a channel instance
+    :param channel_type: channel type code
+    :return: channel instance
+    """
+    ch = Channel()
+    if channel_type == "wx":
+        from channel.wechat.wechat_channel import WechatChannel
+        ch = WechatChannel()
+    elif channel_type == "wxy":
+        from channel.wechat.wechaty_channel import WechatyChannel
+        ch = WechatyChannel()
+    elif channel_type == "terminal":
+        from channel.terminal.terminal_channel import TerminalChannel
+        ch = TerminalChannel()
+    elif channel_type == 'web':
+        from channel.web.web_channel import WebChannel
+        ch = WebChannel()
+    elif channel_type == "wechatmp":
+        from channel.wechatmp.wechatmp_channel import WechatMPChannel
+        ch = WechatMPChannel(passive_reply=True)
+    elif channel_type == "wechatmp_service":
+        from channel.wechatmp.wechatmp_channel import WechatMPChannel
+        ch = WechatMPChannel(passive_reply=False)
+    elif channel_type == "wechatcom_app":
+        from channel.wechatcom.wechatcomapp_channel import WechatComAppChannel
+        ch = WechatComAppChannel()
+    elif channel_type == "wechatcom_service":
+        from channel.wechatcs.wechatcomservice_channel import WechatComServiceChannel
+        ch = WechatComServiceChannel()
+    elif channel_type == "wework":
+        from channel.wework.wework_channel import WeworkChannel
+        ch = WeworkChannel()
+    elif channel_type == const.FEISHU:
+        from channel.feishu.feishu_channel import FeiShuChanel
+        ch = FeiShuChanel()
+    elif channel_type == const.DINGTALK:
+        from channel.dingtalk.dingtalk_channel import DingTalkChanel
+        ch = DingTalkChanel()
+    elif channel_type == "gewechat":
+        from channel.gewechat.gewechat_channel import GeWeChatChannel
+        ch = GeWeChatChannel()
+    else:
+        raise RuntimeError
+    ch.channel_type = channel_type
+    return ch

--- a/channel/channel/chat_channel.py
+++ b/channel/channel/chat_channel.py
@@ -1,4 +1,5 @@
 import os
+import random
 import re
 import threading
 import time
@@ -9,15 +10,13 @@ from bridge.context import *
 from bridge.reply import *
 from channel.channel import Channel
 from common.dequeue import Dequeue
-from common import memory
+from config import conf, config
 from plugins import *
 
 try:
     from voice.audio_convert import any_to_wav
 except Exception as e:
     pass
-
-handler_pool = ThreadPoolExecutor(max_workers=8)  # 处理消息的线程池
 
 
 # 抽象类, 它包含了与消息通道无关的通用处理逻辑
@@ -27,18 +26,19 @@ class ChatChannel(Channel):
     futures = {}  # 记录每个session_id提交到线程池的future对象, 用于重置会话时把没执行的future取消掉，正在执行的不会被取消
     sessions = {}  # 用于控制并发，每个session_id同时只能有一个context在处理
     lock = threading.Lock()  # 用于控制对sessions的访问
+    handler_pool = ThreadPoolExecutor(max_workers=8)  # 处理消息的线程池
 
     def __init__(self):
+        self.should_stop = False
         _thread = threading.Thread(target=self.consume)
         _thread.setDaemon(True)
         _thread.start()
 
     # 根据消息构造context，消息内容相关的触发项写在这里
     def _compose_context(self, ctype: ContextType, content, **kwargs):
+        config = conf()
         context = Context(ctype, content)
         context.kwargs = kwargs
-        if ctype == ContextType.ACCEPT_FRIEND:
-            return context
         # context首次传入时，origin_ctype是None,
         # 引入的起因是：当输入语音时，会嵌套生成两个context，第一步语音转文本，第二步通过文本生成文字回复。
         # origin_ctype用于第二步文本回复时，判断是否需要匹配前缀，如果是私聊的语音，就不需要匹配前缀
@@ -56,10 +56,11 @@ class ChatChannel(Channel):
             if context.get("isgroup", False):
                 group_name = cmsg.other_user_nickname
                 group_id = cmsg.other_user_id
-                context["group_name"] = group_name
-
+                logger.debug(f"正在处理群组消息，群名：{group_name}, 群ID：{group_id}")
+                # print(f"正在处理群组消息，群名：{group_name}, 群ID：{group_id}")
                 group_name_white_list = config.get("group_name_white_list", [])
                 group_name_keyword_white_list = config.get("group_name_keyword_white_list", [])
+
                 if any(
                         [
                             group_name in group_name_white_list,
@@ -68,8 +69,9 @@ class ChatChannel(Channel):
                         ]
                 ):
                     group_chat_in_one_session = conf().get("group_chat_in_one_session", [])
-                    session_id = f"{cmsg.actual_user_id}@@{group_id}" # 当群聊未共享session时，session_id为user_id与group_id的组合，用于区分不同群聊以及单聊
-                    context["is_shared_session_group"] = False  # 默认为非共享会话群
+                    session_id = cmsg.actual_user_id
+                    if session_id is None or session_id == "":
+                        session_id = group_id
                     if any(
                             [
                                 group_name in group_chat_in_one_session,
@@ -77,81 +79,83 @@ class ChatChannel(Channel):
                             ]
                     ):
                         session_id = group_id
-                        context["is_shared_session_group"] = True  # 如果是共享会话群，设置为True
+
                 else:
-                    logger.debug(f"No need reply, groupName not in whitelist, group_name={group_name}")
                     return None
                 context["session_id"] = session_id
                 context["receiver"] = group_id
             else:
                 context["session_id"] = cmsg.other_user_id
                 context["receiver"] = cmsg.other_user_id
-            e_context = PluginManager().emit_event(EventContext(Event.ON_RECEIVE_MESSAGE, {"channel": self, "context": context}))
+
+            logger.debug(f"最终的会话ID：{context['session_id']}")
+            logger.debug(f"最终的接收者ID：{context['receiver']}")
+            e_context = PluginManager().emit_event(
+                EventContext(Event.ON_RECEIVE_MESSAGE, {"channel": self, "context": context}))
             context = e_context["context"]
             if e_context.is_pass() or context is None:
                 return context
-            if cmsg.from_user_id == self.user_id and not config.get("trigger_by_self", True):
-                logger.debug("[chat_channel]self message skipped")
+
+            if cmsg.from_user_id == self.user_id and not config.get("trigger_by_self", False):
+                logger.debug("[WX]self message skipped")
                 return None
 
         # 消息内容匹配过程，并处理content
         if ctype == ContextType.TEXT:
-            nick_name_black_list = conf().get("nick_name_black_list", [])
-            if context.get("isgroup", False):  # 群聊
-                # 校验关键字
-                match_prefix = check_prefix(content, conf().get("group_chat_prefix"))
-                match_contain = check_contain(content, conf().get("group_chat_keyword"))
-                flag = False
-                if context["msg"].to_user_id != context["msg"].actual_user_id:
-                    if match_prefix is not None or match_contain is not None:
-                        flag = True
-                        if match_prefix:
-                            content = content.replace(match_prefix, "", 1).strip()
-                    if context["msg"].is_at:
-                        nick_name = context["msg"].actual_user_nickname
-                        if nick_name and nick_name in nick_name_black_list:
-                            # 黑名单过滤
-                            logger.warning(f"[chat_channel] Nickname {nick_name} in In BlackList, ignore")
-                            return None
+            # if first_in and "」\n- - - - - - -" in content:  # 初次匹配 过滤引用消息
+            #     start_idx = content.find("「") + 1  # 找到「的位置
+            #     end_idx = content.find("：", start_idx)  # 找到：的位置
+            #     result = content[:start_idx] + content[end_idx+1:]  # 将两部分字符串拼接起来
+            #     content=result
+                #print(content)  # 输出结果
 
-                        logger.info("[chat_channel]receive group at")
-                        if not conf().get("group_at_off", False):
-                            flag = True
-                        self.name = self.name if self.name is not None else ""  # 部分渠道self.name可能没有赋值
+            if context.get("isgroup", False):  # 群聊
+                match_prefix = check_prefix(content, conf().get("group_chat_prefix"))
+                match_suffix = check_suffix(content, conf().get("group_chat_suffix"))
+                match_contain = check_contain(content, conf().get("group_chat_keyword"))
+                group_userid_black_list = config.get("group_userid_black_list", [])
+                flag = False
+                if match_prefix is not None or match_contain is not None or match_suffix is not None :
+                    flag = True
+                    if match_prefix:
+                        content = content.replace(match_prefix, "", 1).strip()
+                if context["msg"].is_at:
+                    logger.info("[WX]receive group at")
+                    # 群用户ID黑名单
+                    if context["msg"].actual_user_id in group_userid_black_list:
+                        logger.info("[WX]该用户在黑名单中，不作回复")
+                        return None
+                    if not conf().get("group_at_off", False):
+                        flag = True
+                    # 确保self.name不为None，避免re.escape出错
+                    if self.name is not None:
                         pattern = f"@{re.escape(self.name)}(\u2005|\u0020)"
+                    else:
+                        pattern = "@(\u2005|\u0020)"  # 如果self.name为None，使用一个通用模式
+                    subtract_res = re.sub(pattern, r"", content)
+                    if subtract_res == content and context["msg"].self_display_name:
+                        pattern = f"@{re.escape(context['msg'].self_display_name)}(\u2005|\u0020)"
+                        subtract_res = re.sub(pattern, r"", subtract_res)
+                    if subtract_res == content and context["msg"].self_display_name:
+                        # 前缀移除后没有变化，使用群昵称再次移除
+                        pattern = f"@{re.escape(context['msg'].self_display_name)}(\u2005|\u0020)"
                         subtract_res = re.sub(pattern, r"", content)
-                        if isinstance(context["msg"].at_list, list):
-                            for at in context["msg"].at_list:
-                                pattern = f"@{re.escape(at)}(\u2005|\u0020)"
-                                subtract_res = re.sub(pattern, r"", subtract_res)
-                        if subtract_res == content and context["msg"].self_display_name:
-                            # 前缀移除后没有变化，使用群昵称再次移除
-                            pattern = f"@{re.escape(context['msg'].self_display_name)}(\u2005|\u0020)"
-                            subtract_res = re.sub(pattern, r"", content)
-                        content = subtract_res
+                    content = subtract_res
                 if not flag:
                     if context["origin_ctype"] == ContextType.VOICE:
-                        logger.info("[chat_channel]receive group voice, but checkprefix didn't match")
-                    return None
-            else:  # 单聊
-                nick_name = context["msg"].from_user_nickname
-                if nick_name and nick_name in nick_name_black_list:
-                    # 黑名单过滤
-                    logger.warning(f"[chat_channel] Nickname '{nick_name}' in In BlackList, ignore")
+                        logger.info("[WX]发现群内语音, 但无触发前缀，bot不回复")
                     return None
 
+            else:  # 单聊
                 match_prefix = check_prefix(content, conf().get("single_chat_prefix", [""]))
                 if match_prefix is not None:  # 判断如果匹配到自定义前缀，则返回过滤掉前缀+空格后的内容
                     content = content.replace(match_prefix, "", 1).strip()
-                elif self.channel_type == 'wechatcom_app':
-                    # todo:企业微信自建应用不需要前导字符
-                    pass
                 elif context["origin_ctype"] == ContextType.VOICE:  # 如果源消息是私聊的语音消息，允许不匹配前缀，放宽条件
                     pass
                 else:
                     return None
             content = content.strip()
-            img_match_prefix = check_prefix(content, conf().get("image_create_prefix",[""]))
+            img_match_prefix = check_prefix(content, conf().get("image_create_prefix"))
             if img_match_prefix:
                 content = content.replace(img_match_prefix, "", 1)
                 context.type = ContextType.IMAGE_CREATE
@@ -161,27 +165,45 @@ class ChatChannel(Channel):
             if "desire_rtype" not in context and conf().get(
                     "always_reply_voice") and ReplyType.VOICE not in self.NOT_SUPPORT_REPLYTYPE:
                 context["desire_rtype"] = ReplyType.VOICE
+        elif ctype == ContextType.QUOTE:
+            cmsg = context["msg"]
+            refname_text = cmsg.to_user_id
+            msg_text = content
+            if refname_text == self.user_id:
+                context.content = msg_text
+                context.type = ContextType.TEXT
+            else:
+                # 如果不是AI，则可能忽略这条消息或使用不同的逻辑处理
+                return None  # 忽略或替换为其他处理逻辑
+        elif ctype == ContextType.WCPAY:
+            pass
+            # msg_text = content
+        elif ctype == ContextType.MP:
+            return
+        elif ctype == ContextType.LEAVE_GROUP:
+            pass
+        elif ctype == ContextType.EXIT_GROUP:
+            pass
         elif context.type == ContextType.VOICE:
             if "desire_rtype" not in context and conf().get(
                     "voice_reply_voice") and ReplyType.VOICE not in self.NOT_SUPPORT_REPLYTYPE:
                 context["desire_rtype"] = ReplyType.VOICE
+
         return context
 
     def _handle(self, context: Context):
         if context is None or not context.content:
             return
-        logger.debug("[chat_channel] ready to handle context: {}".format(context))
+        logger.debug("[WX] ready to handle context: {}".format(context))
         # reply的构建步骤
         reply = self._generate_reply(context)
 
-        logger.debug("[chat_channel] ready to decorate reply: {}".format(reply))
-
+        logger.debug("[WX] ready to decorate reply: {}".format(reply))
         # reply的包装步骤
-        if reply and reply.content:
-            reply = self._decorate_reply(context, reply)
+        reply = self._decorate_reply(context, reply)
 
-            # reply的发送步骤
-            self._send_reply(context, reply)
+        # reply的发送步骤
+        self._send_reply(context, reply)
 
     def _generate_reply(self, context: Context, reply: Reply = Reply()) -> Reply:
         e_context = PluginManager().emit_event(
@@ -192,9 +214,10 @@ class ChatChannel(Channel):
         )
         reply = e_context["reply"]
         if not e_context.is_pass():
-            logger.debug("[chat_channel] ready to handle context: type={}, content={}".format(context.type, context.content))
+            logger.debug("[WX] ready to handle context: type={}, content={}".format(context.type, context.content))
+            if e_context.is_break():
+                context["generate_breaked_by"] = e_context["breaked_by"]
             if context.type == ContextType.TEXT or context.type == ContextType.IMAGE_CREATE:  # 文字和图片消息
-                context["channel"] = e_context["channel"]
                 reply = super().build_reply_content(context.content, context)
             elif context.type == ContextType.VOICE:  # 语音消息
                 cmsg = context["msg"]
@@ -204,7 +227,7 @@ class ChatChannel(Channel):
                 try:
                     any_to_wav(file_path, wav_path)
                 except Exception as e:  # 转换失败，直接使用mp3，对于某些api，mp3也可以识别
-                    logger.warning("[chat_channel]any to wav error, use raw path. " + str(e))
+                    logger.warning("[WX]any to wav error, use raw path. " + str(e))
                     wav_path = file_path
                 # 语音识别
                 reply = super().build_voice_to_text(wav_path)
@@ -215,7 +238,7 @@ class ChatChannel(Channel):
                         os.remove(wav_path)
                 except Exception as e:
                     pass
-                    # logger.warning("[chat_channel]delete temp file error: " + str(e))
+                    # logger.warning("[WX]delete temp file error: " + str(e))
 
                 if reply.type == ReplyType.TEXT:
                     new_context = self._compose_context(ContextType.TEXT, reply.content, **context.kwargs)
@@ -223,19 +246,51 @@ class ChatChannel(Channel):
                         reply = self._generate_reply(new_context)
                     else:
                         return
-            elif context.type == ContextType.IMAGE:  # 图片消息，当前仅做下载保存到本地的逻辑
-                memory.USER_IMAGE_CACHE[context["session_id"]] = {
-                    "path": context.content,
-                    "msg": context.get("msg")
-                }
-            elif context.type == ContextType.ACCEPT_FRIEND:  # 好友申请，匹配字符串
-                reply = self._build_friend_request_reply(context)
-            elif context.type == ContextType.SHARING:  # 分享信息，当前无默认逻辑
-                pass
+            elif context.type == ContextType.IMAGE:
+                cmsg = context["msg"]
+                cmsg.prepare()
+            elif context.type == ContextType.LEAVE_GROUP:
+                if config.get("group_chat_exit_group"):
+                    reply = Reply()
+                    reply.type = ReplyType.INFO
+                    reply.content = context.content
+                else:
+                    pass
             elif context.type == ContextType.FUNCTION or context.type == ContextType.FILE:  # 文件消息及函数调用等，当前无默认逻辑
                 pass
+            # 未来可自定义逻辑
+            elif context.type == ContextType.XML:
+                pass
+            elif context.type == ContextType.SHARING:
+                pass
+            elif context.type == ContextType.CARD:
+                pass
+            elif context.type == ContextType.VIDEO:
+                pass
+            elif context.type == ContextType.EMOJI:
+                pass
+            elif context.type == ContextType.PATPAT:
+                pass
+            elif context.type == ContextType.QUOTE:
+                pass
+            elif context.type == ContextType.MINIAPP:
+                pass
+            elif context.type == ContextType.JOIN_GROUP:
+                pass
+            elif context.type == ContextType.EXIT_GROUP:
+                pass
+            elif context.type == ContextType.SYSTEM:
+                pass
+            elif context.type == ContextType.WCPAY:
+                pass
+            elif context.type == ContextType.WECHAT_VIDEO:
+                pass
+            elif context.type == ContextType.MP:
+                pass
+            elif context.type == ContextType.MP_LINK:
+                pass
             else:
-                logger.warning("[chat_channel] unknown context type: {}".format(context.type))
+                logger.error("[WX] unknown context type: {}".format(context.type))
                 return
         return reply
 
@@ -249,9 +304,10 @@ class ChatChannel(Channel):
             )
             reply = e_context["reply"]
             desire_rtype = context.get("desire_rtype")
+            logger.debug(f"context:{context}")
             if not e_context.is_pass() and reply and reply.type:
                 if reply.type in self.NOT_SUPPORT_REPLYTYPE:
-                    logger.error("[chat_channel]reply type not support: " + str(reply.type))
+                    logger.error("[WX]reply type not support: " + str(reply.type))
                     reply.type = ReplyType.ERROR
                     reply.content = "不支持发送的消息类型: " + str(reply.type)
 
@@ -261,28 +317,46 @@ class ChatChannel(Channel):
                         reply = super().build_text_to_voice(reply.content)
                         return self._decorate_reply(context, reply)
                     if context.get("isgroup", False):
-                        if not conf().get("no_need_at", False):
-                            reply_text = "@" + context["msg"].actual_user_nickname + "\n" + reply_text.strip()
+                        nickname = context["msg"].actual_user_nickname if context["msg"].actual_user_nickname is not None else "提问用户"
+                        reply_text = "@" + context["msg"].actual_user_nickname + "\n" + reply_text.strip()
                         reply_text = conf().get("group_chat_reply_prefix", "") + reply_text + conf().get(
                             "group_chat_reply_suffix", "")
                     else:
                         reply_text = conf().get("single_chat_reply_prefix", "") + reply_text + conf().get(
                             "single_chat_reply_suffix", "")
                     reply.content = reply_text
+
                 elif reply.type == ReplyType.ERROR or reply.type == ReplyType.INFO:
                     reply.content = "[" + str(reply.type) + "]\n" + reply.content
-                elif reply.type == ReplyType.IMAGE_URL or reply.type == ReplyType.VOICE or reply.type == ReplyType.IMAGE or reply.type == ReplyType.FILE or reply.type == ReplyType.VIDEO or reply.type == ReplyType.VIDEO_URL:
+                elif reply.type == ReplyType.IMAGE_URL or reply.type == ReplyType.VOICE or reply.type == ReplyType.IMAGE:
                     pass
-                elif reply.type == ReplyType.ACCEPT_FRIEND:
+                elif reply.type == ReplyType.VIDEO_URL:
+                    pass
+                elif reply.type == ReplyType.CARD:
+                    pass
+                elif reply.type == ReplyType.InviteRoom:
+                    pass
+                elif reply.type == ReplyType.TEXT_:
+                    pass
+                elif reply.type == ReplyType.FILE:
+                    pass
+                elif reply.type == ReplyType.MINIAPP:
+                    pass
+                elif reply.type == ReplyType.LINK:
+                    pass
+                elif reply.type == ReplyType.CALL_UP:
+                    pass
+                elif reply.type == ReplyType.GIF:
                     pass
                 elif reply.type == ReplyType.XML:
                     # XML 类型回复不需要额外处理，直接传递给发送方法
                     pass
                 else:
-                    logger.error("[chat_channel] unknown reply type: {}".format(reply.type))
+                    logger.error("[WX] unknown reply type: {}".format(reply.type))
                     return
             if desire_rtype and desire_rtype != reply.type and reply.type not in [ReplyType.ERROR, ReplyType.INFO]:
-                logger.warning("[chat_channel] desire_rtype: {}, but reply type: {}".format(context.get("desire_rtype"), reply.type))
+                logger.warning(
+                    "[WX] desire_rtype: {}, but reply type: {}".format(context.get("desire_rtype"), reply.type))
             return reply
 
     def _send_reply(self, context: Context, reply: Reply):
@@ -295,32 +369,20 @@ class ChatChannel(Channel):
             )
             reply = e_context["reply"]
             if not e_context.is_pass() and reply and reply.type:
-                logger.debug("[chat_channel] ready to send reply: {}, context: {}".format(reply, context))
+                logger.debug("[WX] ready to send reply: {}, context: {}".format(reply, context))
                 self._send(reply, context)
 
     def _send(self, reply: Reply, context: Context, retry_cnt=0):
         try:
             self.send(reply, context)
         except Exception as e:
-            logger.error("[chat_channel] sendMsg error: {}".format(str(e)))
+            logger.error("[WX] sendMsg error: {}".format(str(e)))
             if isinstance(e, NotImplementedError):
                 return
             logger.exception(e)
             if retry_cnt < 2:
                 time.sleep(3 + 3 * retry_cnt)
                 self._send(reply, context, retry_cnt + 1)
-
-    # 处理好友申请
-    def _build_friend_request_reply(self, context):
-        if isinstance(context.content, dict) and "Content" in context.content:
-            logger.info("friend request content: {}".format(context.content["Content"]))
-            if context.content["Content"] in conf().get("accept_friend_commands", []):
-                return Reply(type=ReplyType.ACCEPT_FRIEND, content=True)
-            else:
-                return Reply(type=ReplyType.ACCEPT_FRIEND, content=False)
-        else:
-            logger.error("Invalid context content: {}".format(context.content))
-            return None
 
     def _success_callback(self, session_id, **kwargs):  # 线程正常结束时的回调函数
         logger.debug("Worker return success, session_id = {}".format(session_id))
@@ -342,11 +404,13 @@ class ChatChannel(Channel):
                 logger.exception("Worker raise exception: {}".format(e))
             with self.lock:
                 self.sessions[session_id][1].release()
+            ###
 
         return func
 
     def produce(self, context: Context):
-        session_id = context.get("session_id", 0)
+        session_id = context["session_id"]
+        # print(self.sessions)
         with self.lock:
             if session_id not in self.sessions:
                 self.sessions[session_id] = [
@@ -360,30 +424,27 @@ class ChatChannel(Channel):
 
     # 消费者函数，单独线程，用于从消息队列中取出消息并处理
     def consume(self):
+        logger.debug("[ChatChannel] consume method started.")
         while True:
             with self.lock:
                 session_ids = list(self.sessions.keys())
-            for session_id in session_ids:
-                with self.lock:
+                for session_id in session_ids:
                     context_queue, semaphore = self.sessions[session_id]
-                if semaphore.acquire(blocking=False):  # 等线程处理完毕才能删除
-                    if not context_queue.empty():
-                        context = context_queue.get()
-                        logger.debug("[chat_channel] consume context: {}".format(context))
-                        future: Future = handler_pool.submit(self._handle, context)
-                        future.add_done_callback(self._thread_pool_callback(session_id, context=context))
-                        with self.lock:
+                    if semaphore.acquire(blocking=False):  # 等线程处理完毕才能删除
+                        if not context_queue.empty():
+                            context = context_queue.get()
+                            future: Future = self.handler_pool.submit(self._handle, context)
+                            future.add_done_callback(self._thread_pool_callback(session_id, context=context))
                             if session_id not in self.futures:
                                 self.futures[session_id] = []
                             self.futures[session_id].append(future)
-                    elif semaphore._initial_value == semaphore._value + 1:  # 除了当前，没有任务再申请到信号量，说明所有任务都处理完毕
-                        with self.lock:
+                        elif semaphore._initial_value == semaphore._value + 1:  # 除了当前，没有任务再申请到信号量，说明所有任务都处理完毕
                             self.futures[session_id] = [t for t in self.futures[session_id] if not t.done()]
                             assert len(self.futures[session_id]) == 0, "thread pool error"
                             del self.sessions[session_id]
-                    else:
-                        semaphore.release()
-            time.sleep(0.2)
+                        else:
+                            semaphore.release()
+            time.sleep(0.1)
 
     # 取消session_id对应的所有任务，只能取消排队的消息和已提交线程池但未执行的任务
     def cancel_session(self, session_id):
@@ -406,15 +467,24 @@ class ChatChannel(Channel):
                     logger.info("Cancel {} messages in session {}".format(cnt, session_id))
                 self.sessions[session_id][0] = Dequeue()
 
+    def stop(self):
+        self.should_stop = True
+
 
 def check_prefix(content, prefix_list):
     if not prefix_list:
         return None
     for prefix in prefix_list:
-        if content.startswith(prefix):
+        if content.lower().startswith(prefix):
             return prefix
     return None
-
+def check_suffix(content, prefix_list):
+    if not prefix_list:
+        return None
+    for prefix in prefix_list:
+        if content.lower().endswith(prefix):
+            return prefix
+    return None
 
 def check_contain(content, keyword_list):
     if not keyword_list:

--- a/channel/channel/chat_channel.py.bak
+++ b/channel/channel/chat_channel.py.bak
@@ -1,4 +1,5 @@
 import os
+import random
 import re
 import threading
 import time
@@ -9,15 +10,13 @@ from bridge.context import *
 from bridge.reply import *
 from channel.channel import Channel
 from common.dequeue import Dequeue
-from common import memory
+from config import conf, config
 from plugins import *
 
 try:
     from voice.audio_convert import any_to_wav
 except Exception as e:
     pass
-
-handler_pool = ThreadPoolExecutor(max_workers=8)  # 处理消息的线程池
 
 
 # 抽象类, 它包含了与消息通道无关的通用处理逻辑
@@ -27,18 +26,19 @@ class ChatChannel(Channel):
     futures = {}  # 记录每个session_id提交到线程池的future对象, 用于重置会话时把没执行的future取消掉，正在执行的不会被取消
     sessions = {}  # 用于控制并发，每个session_id同时只能有一个context在处理
     lock = threading.Lock()  # 用于控制对sessions的访问
+    handler_pool = ThreadPoolExecutor(max_workers=8)  # 处理消息的线程池
 
     def __init__(self):
+        self.should_stop = False
         _thread = threading.Thread(target=self.consume)
         _thread.setDaemon(True)
         _thread.start()
 
     # 根据消息构造context，消息内容相关的触发项写在这里
     def _compose_context(self, ctype: ContextType, content, **kwargs):
+        config = conf()
         context = Context(ctype, content)
         context.kwargs = kwargs
-        if ctype == ContextType.ACCEPT_FRIEND:
-            return context
         # context首次传入时，origin_ctype是None,
         # 引入的起因是：当输入语音时，会嵌套生成两个context，第一步语音转文本，第二步通过文本生成文字回复。
         # origin_ctype用于第二步文本回复时，判断是否需要匹配前缀，如果是私聊的语音，就不需要匹配前缀
@@ -56,10 +56,11 @@ class ChatChannel(Channel):
             if context.get("isgroup", False):
                 group_name = cmsg.other_user_nickname
                 group_id = cmsg.other_user_id
-                context["group_name"] = group_name
-
+                logger.debug(f"正在处理群组消息，群名：{group_name}, 群ID：{group_id}")
+                # print(f"正在处理群组消息，群名：{group_name}, 群ID：{group_id}")
                 group_name_white_list = config.get("group_name_white_list", [])
                 group_name_keyword_white_list = config.get("group_name_keyword_white_list", [])
+
                 if any(
                         [
                             group_name in group_name_white_list,
@@ -68,8 +69,9 @@ class ChatChannel(Channel):
                         ]
                 ):
                     group_chat_in_one_session = conf().get("group_chat_in_one_session", [])
-                    session_id = f"{cmsg.actual_user_id}@@{group_id}" # 当群聊未共享session时，session_id为user_id与group_id的组合，用于区分不同群聊以及单聊
-                    context["is_shared_session_group"] = False  # 默认为非共享会话群
+                    session_id = cmsg.actual_user_id
+                    if session_id is None or session_id == "":
+                        session_id = group_id
                     if any(
                             [
                                 group_name in group_chat_in_one_session,
@@ -77,81 +79,79 @@ class ChatChannel(Channel):
                             ]
                     ):
                         session_id = group_id
-                        context["is_shared_session_group"] = True  # 如果是共享会话群，设置为True
+
                 else:
-                    logger.debug(f"No need reply, groupName not in whitelist, group_name={group_name}")
                     return None
                 context["session_id"] = session_id
                 context["receiver"] = group_id
             else:
                 context["session_id"] = cmsg.other_user_id
                 context["receiver"] = cmsg.other_user_id
-            e_context = PluginManager().emit_event(EventContext(Event.ON_RECEIVE_MESSAGE, {"channel": self, "context": context}))
+
+            logger.debug(f"最终的会话ID：{context['session_id']}")
+            logger.debug(f"最终的接收者ID：{context['receiver']}")
+            e_context = PluginManager().emit_event(
+                EventContext(Event.ON_RECEIVE_MESSAGE, {"channel": self, "context": context}))
             context = e_context["context"]
             if e_context.is_pass() or context is None:
                 return context
-            if cmsg.from_user_id == self.user_id and not config.get("trigger_by_self", True):
-                logger.debug("[chat_channel]self message skipped")
+
+            if cmsg.from_user_id == self.user_id and not config.get("trigger_by_self", False):
+                logger.debug("[WX]self message skipped")
                 return None
 
         # 消息内容匹配过程，并处理content
         if ctype == ContextType.TEXT:
-            nick_name_black_list = conf().get("nick_name_black_list", [])
-            if context.get("isgroup", False):  # 群聊
-                # 校验关键字
-                match_prefix = check_prefix(content, conf().get("group_chat_prefix"))
-                match_contain = check_contain(content, conf().get("group_chat_keyword"))
-                flag = False
-                if context["msg"].to_user_id != context["msg"].actual_user_id:
-                    if match_prefix is not None or match_contain is not None:
-                        flag = True
-                        if match_prefix:
-                            content = content.replace(match_prefix, "", 1).strip()
-                    if context["msg"].is_at:
-                        nick_name = context["msg"].actual_user_nickname
-                        if nick_name and nick_name in nick_name_black_list:
-                            # 黑名单过滤
-                            logger.warning(f"[chat_channel] Nickname {nick_name} in In BlackList, ignore")
-                            return None
+            # if first_in and "」\n- - - - - - -" in content:  # 初次匹配 过滤引用消息
+            #     start_idx = content.find("「") + 1  # 找到「的位置
+            #     end_idx = content.find("：", start_idx)  # 找到：的位置
+            #     result = content[:start_idx] + content[end_idx+1:]  # 将两部分字符串拼接起来
+            #     content=result
+                #print(content)  # 输出结果
 
-                        logger.info("[chat_channel]receive group at")
-                        if not conf().get("group_at_off", False):
-                            flag = True
-                        self.name = self.name if self.name is not None else ""  # 部分渠道self.name可能没有赋值
-                        pattern = f"@{re.escape(self.name)}(\u2005|\u0020)"
+            if context.get("isgroup", False):  # 群聊
+                match_prefix = check_prefix(content, conf().get("group_chat_prefix"))
+                match_suffix = check_suffix(content, conf().get("group_chat_suffix"))
+                match_contain = check_contain(content, conf().get("group_chat_keyword"))
+                group_userid_black_list = config.get("group_userid_black_list", [])
+                flag = False
+                if match_prefix is not None or match_contain is not None or match_suffix is not None :
+                    flag = True
+                    if match_prefix:
+                        content = content.replace(match_prefix, "", 1).strip()
+                if context["msg"].is_at:
+                    logger.info("[WX]receive group at")
+                    # 群用户ID黑名单
+                    if context["msg"].actual_user_id in group_userid_black_list:
+                        logger.info("[WX]该用户在黑名单中，不作回复")
+                        return None
+                    if not conf().get("group_at_off", False):
+                        flag = True
+                    pattern = f"@{re.escape(self.name)}(\u2005|\u0020)"
+                    subtract_res = re.sub(pattern, r"", content)
+                    if subtract_res == content and context["msg"].self_display_name:
+                        pattern = f"@{re.escape(context['msg'].self_display_name)}(\u2005|\u0020)"
+                        subtract_res = re.sub(pattern, r"", subtract_res)
+                    if subtract_res == content and context["msg"].self_display_name:
+                        # 前缀移除后没有变化，使用群昵称再次移除
+                        pattern = f"@{re.escape(context['msg'].self_display_name)}(\u2005|\u0020)"
                         subtract_res = re.sub(pattern, r"", content)
-                        if isinstance(context["msg"].at_list, list):
-                            for at in context["msg"].at_list:
-                                pattern = f"@{re.escape(at)}(\u2005|\u0020)"
-                                subtract_res = re.sub(pattern, r"", subtract_res)
-                        if subtract_res == content and context["msg"].self_display_name:
-                            # 前缀移除后没有变化，使用群昵称再次移除
-                            pattern = f"@{re.escape(context['msg'].self_display_name)}(\u2005|\u0020)"
-                            subtract_res = re.sub(pattern, r"", content)
-                        content = subtract_res
+                    content = subtract_res
                 if not flag:
                     if context["origin_ctype"] == ContextType.VOICE:
-                        logger.info("[chat_channel]receive group voice, but checkprefix didn't match")
-                    return None
-            else:  # 单聊
-                nick_name = context["msg"].from_user_nickname
-                if nick_name and nick_name in nick_name_black_list:
-                    # 黑名单过滤
-                    logger.warning(f"[chat_channel] Nickname '{nick_name}' in In BlackList, ignore")
+                        logger.info("[WX]发现群内语音, 但无触发前缀，bot不回复")
                     return None
 
+            else:  # 单聊
                 match_prefix = check_prefix(content, conf().get("single_chat_prefix", [""]))
                 if match_prefix is not None:  # 判断如果匹配到自定义前缀，则返回过滤掉前缀+空格后的内容
                     content = content.replace(match_prefix, "", 1).strip()
-                elif self.channel_type == 'wechatcom_app':
-                    # todo:企业微信自建应用不需要前导字符
-                    pass
                 elif context["origin_ctype"] == ContextType.VOICE:  # 如果源消息是私聊的语音消息，允许不匹配前缀，放宽条件
                     pass
                 else:
                     return None
             content = content.strip()
-            img_match_prefix = check_prefix(content, conf().get("image_create_prefix",[""]))
+            img_match_prefix = check_prefix(content, conf().get("image_create_prefix"))
             if img_match_prefix:
                 content = content.replace(img_match_prefix, "", 1)
                 context.type = ContextType.IMAGE_CREATE
@@ -161,27 +161,45 @@ class ChatChannel(Channel):
             if "desire_rtype" not in context and conf().get(
                     "always_reply_voice") and ReplyType.VOICE not in self.NOT_SUPPORT_REPLYTYPE:
                 context["desire_rtype"] = ReplyType.VOICE
+        elif ctype == ContextType.QUOTE:
+            cmsg = context["msg"]
+            refname_text = cmsg.to_user_id
+            msg_text = content
+            if refname_text == self.user_id:
+                context.content = msg_text
+                context.type = ContextType.TEXT
+            else:
+                # 如果不是AI，则可能忽略这条消息或使用不同的逻辑处理
+                return None  # 忽略或替换为其他处理逻辑
+        elif ctype == ContextType.WCPAY:
+            pass
+            # msg_text = content
+        elif ctype == ContextType.MP:
+            return
+        elif ctype == ContextType.LEAVE_GROUP:
+            pass
+        elif ctype == ContextType.EXIT_GROUP:
+            pass
         elif context.type == ContextType.VOICE:
             if "desire_rtype" not in context and conf().get(
                     "voice_reply_voice") and ReplyType.VOICE not in self.NOT_SUPPORT_REPLYTYPE:
                 context["desire_rtype"] = ReplyType.VOICE
+
         return context
 
     def _handle(self, context: Context):
         if context is None or not context.content:
             return
-        logger.debug("[chat_channel] ready to handle context: {}".format(context))
+        logger.debug("[WX] ready to handle context: {}".format(context))
         # reply的构建步骤
         reply = self._generate_reply(context)
 
-        logger.debug("[chat_channel] ready to decorate reply: {}".format(reply))
-
+        logger.debug("[WX] ready to decorate reply: {}".format(reply))
         # reply的包装步骤
-        if reply and reply.content:
-            reply = self._decorate_reply(context, reply)
+        reply = self._decorate_reply(context, reply)
 
-            # reply的发送步骤
-            self._send_reply(context, reply)
+        # reply的发送步骤
+        self._send_reply(context, reply)
 
     def _generate_reply(self, context: Context, reply: Reply = Reply()) -> Reply:
         e_context = PluginManager().emit_event(
@@ -192,9 +210,10 @@ class ChatChannel(Channel):
         )
         reply = e_context["reply"]
         if not e_context.is_pass():
-            logger.debug("[chat_channel] ready to handle context: type={}, content={}".format(context.type, context.content))
+            logger.debug("[WX] ready to handle context: type={}, content={}".format(context.type, context.content))
+            if e_context.is_break():
+                context["generate_breaked_by"] = e_context["breaked_by"]
             if context.type == ContextType.TEXT or context.type == ContextType.IMAGE_CREATE:  # 文字和图片消息
-                context["channel"] = e_context["channel"]
                 reply = super().build_reply_content(context.content, context)
             elif context.type == ContextType.VOICE:  # 语音消息
                 cmsg = context["msg"]
@@ -204,7 +223,7 @@ class ChatChannel(Channel):
                 try:
                     any_to_wav(file_path, wav_path)
                 except Exception as e:  # 转换失败，直接使用mp3，对于某些api，mp3也可以识别
-                    logger.warning("[chat_channel]any to wav error, use raw path. " + str(e))
+                    logger.warning("[WX]any to wav error, use raw path. " + str(e))
                     wav_path = file_path
                 # 语音识别
                 reply = super().build_voice_to_text(wav_path)
@@ -215,7 +234,7 @@ class ChatChannel(Channel):
                         os.remove(wav_path)
                 except Exception as e:
                     pass
-                    # logger.warning("[chat_channel]delete temp file error: " + str(e))
+                    # logger.warning("[WX]delete temp file error: " + str(e))
 
                 if reply.type == ReplyType.TEXT:
                     new_context = self._compose_context(ContextType.TEXT, reply.content, **context.kwargs)
@@ -223,19 +242,51 @@ class ChatChannel(Channel):
                         reply = self._generate_reply(new_context)
                     else:
                         return
-            elif context.type == ContextType.IMAGE:  # 图片消息，当前仅做下载保存到本地的逻辑
-                memory.USER_IMAGE_CACHE[context["session_id"]] = {
-                    "path": context.content,
-                    "msg": context.get("msg")
-                }
-            elif context.type == ContextType.ACCEPT_FRIEND:  # 好友申请，匹配字符串
-                reply = self._build_friend_request_reply(context)
-            elif context.type == ContextType.SHARING:  # 分享信息，当前无默认逻辑
-                pass
+            elif context.type == ContextType.IMAGE:
+                cmsg = context["msg"]
+                cmsg.prepare()
+            elif context.type == ContextType.LEAVE_GROUP:
+                if config.get("group_chat_exit_group"):
+                    reply = Reply()
+                    reply.type = ReplyType.INFO
+                    reply.content = context.content
+                else:
+                    pass
             elif context.type == ContextType.FUNCTION or context.type == ContextType.FILE:  # 文件消息及函数调用等，当前无默认逻辑
                 pass
+            # 未来可自定义逻辑
+            elif context.type == ContextType.XML:
+                pass
+            elif context.type == ContextType.SHARING:
+                pass
+            elif context.type == ContextType.CARD:
+                pass
+            elif context.type == ContextType.VIDEO:
+                pass
+            elif context.type == ContextType.EMOJI:
+                pass
+            elif context.type == ContextType.PATPAT:
+                pass
+            elif context.type == ContextType.QUOTE:
+                pass
+            elif context.type == ContextType.MINIAPP:
+                pass
+            elif context.type == ContextType.JOIN_GROUP:
+                pass
+            elif context.type == ContextType.EXIT_GROUP:
+                pass
+            elif context.type == ContextType.SYSTEM:
+                pass
+            elif context.type == ContextType.WCPAY:
+                pass
+            elif context.type == ContextType.WECHAT_VIDEO:
+                pass
+            elif context.type == ContextType.MP:
+                pass
+            elif context.type == ContextType.MP_LINK:
+                pass
             else:
-                logger.warning("[chat_channel] unknown context type: {}".format(context.type))
+                logger.error("[WX] unknown context type: {}".format(context.type))
                 return
         return reply
 
@@ -249,9 +300,10 @@ class ChatChannel(Channel):
             )
             reply = e_context["reply"]
             desire_rtype = context.get("desire_rtype")
+            logger.debug(f"context:{context}")
             if not e_context.is_pass() and reply and reply.type:
                 if reply.type in self.NOT_SUPPORT_REPLYTYPE:
-                    logger.error("[chat_channel]reply type not support: " + str(reply.type))
+                    logger.error("[WX]reply type not support: " + str(reply.type))
                     reply.type = ReplyType.ERROR
                     reply.content = "不支持发送的消息类型: " + str(reply.type)
 
@@ -261,28 +313,46 @@ class ChatChannel(Channel):
                         reply = super().build_text_to_voice(reply.content)
                         return self._decorate_reply(context, reply)
                     if context.get("isgroup", False):
-                        if not conf().get("no_need_at", False):
-                            reply_text = "@" + context["msg"].actual_user_nickname + "\n" + reply_text.strip()
+                        nickname = context["msg"].actual_user_nickname if context["msg"].actual_user_nickname is not None else "提问用户"
+                        reply_text = "@" + context["msg"].actual_user_nickname + "\n" + reply_text.strip()
                         reply_text = conf().get("group_chat_reply_prefix", "") + reply_text + conf().get(
                             "group_chat_reply_suffix", "")
                     else:
                         reply_text = conf().get("single_chat_reply_prefix", "") + reply_text + conf().get(
                             "single_chat_reply_suffix", "")
                     reply.content = reply_text
+
                 elif reply.type == ReplyType.ERROR or reply.type == ReplyType.INFO:
                     reply.content = "[" + str(reply.type) + "]\n" + reply.content
-                elif reply.type == ReplyType.IMAGE_URL or reply.type == ReplyType.VOICE or reply.type == ReplyType.IMAGE or reply.type == ReplyType.FILE or reply.type == ReplyType.VIDEO or reply.type == ReplyType.VIDEO_URL:
+                elif reply.type == ReplyType.IMAGE_URL or reply.type == ReplyType.VOICE or reply.type == ReplyType.IMAGE:
                     pass
-                elif reply.type == ReplyType.ACCEPT_FRIEND:
+                elif reply.type == ReplyType.VIDEO_URL:
+                    pass
+                elif reply.type == ReplyType.CARD:
+                    pass
+                elif reply.type == ReplyType.InviteRoom:
+                    pass
+                elif reply.type == ReplyType.TEXT_:
+                    pass
+                elif reply.type == ReplyType.FILE:
+                    pass
+                elif reply.type == ReplyType.MINIAPP:
+                    pass
+                elif reply.type == ReplyType.LINK:
+                    pass
+                elif reply.type == ReplyType.CALL_UP:
+                    pass
+                elif reply.type == ReplyType.GIF:
                     pass
                 elif reply.type == ReplyType.XML:
                     # XML 类型回复不需要额外处理，直接传递给发送方法
                     pass
                 else:
-                    logger.error("[chat_channel] unknown reply type: {}".format(reply.type))
+                    logger.error("[WX] unknown reply type: {}".format(reply.type))
                     return
             if desire_rtype and desire_rtype != reply.type and reply.type not in [ReplyType.ERROR, ReplyType.INFO]:
-                logger.warning("[chat_channel] desire_rtype: {}, but reply type: {}".format(context.get("desire_rtype"), reply.type))
+                logger.warning(
+                    "[WX] desire_rtype: {}, but reply type: {}".format(context.get("desire_rtype"), reply.type))
             return reply
 
     def _send_reply(self, context: Context, reply: Reply):
@@ -295,32 +365,20 @@ class ChatChannel(Channel):
             )
             reply = e_context["reply"]
             if not e_context.is_pass() and reply and reply.type:
-                logger.debug("[chat_channel] ready to send reply: {}, context: {}".format(reply, context))
+                logger.debug("[WX] ready to send reply: {}, context: {}".format(reply, context))
                 self._send(reply, context)
 
     def _send(self, reply: Reply, context: Context, retry_cnt=0):
         try:
             self.send(reply, context)
         except Exception as e:
-            logger.error("[chat_channel] sendMsg error: {}".format(str(e)))
+            logger.error("[WX] sendMsg error: {}".format(str(e)))
             if isinstance(e, NotImplementedError):
                 return
             logger.exception(e)
             if retry_cnt < 2:
                 time.sleep(3 + 3 * retry_cnt)
                 self._send(reply, context, retry_cnt + 1)
-
-    # 处理好友申请
-    def _build_friend_request_reply(self, context):
-        if isinstance(context.content, dict) and "Content" in context.content:
-            logger.info("friend request content: {}".format(context.content["Content"]))
-            if context.content["Content"] in conf().get("accept_friend_commands", []):
-                return Reply(type=ReplyType.ACCEPT_FRIEND, content=True)
-            else:
-                return Reply(type=ReplyType.ACCEPT_FRIEND, content=False)
-        else:
-            logger.error("Invalid context content: {}".format(context.content))
-            return None
 
     def _success_callback(self, session_id, **kwargs):  # 线程正常结束时的回调函数
         logger.debug("Worker return success, session_id = {}".format(session_id))
@@ -342,11 +400,13 @@ class ChatChannel(Channel):
                 logger.exception("Worker raise exception: {}".format(e))
             with self.lock:
                 self.sessions[session_id][1].release()
+            ###
 
         return func
 
     def produce(self, context: Context):
-        session_id = context.get("session_id", 0)
+        session_id = context["session_id"]
+        # print(self.sessions)
         with self.lock:
             if session_id not in self.sessions:
                 self.sessions[session_id] = [
@@ -360,30 +420,27 @@ class ChatChannel(Channel):
 
     # 消费者函数，单独线程，用于从消息队列中取出消息并处理
     def consume(self):
+        logger.debug("[ChatChannel] consume method started.")
         while True:
             with self.lock:
                 session_ids = list(self.sessions.keys())
-            for session_id in session_ids:
-                with self.lock:
+                for session_id in session_ids:
                     context_queue, semaphore = self.sessions[session_id]
-                if semaphore.acquire(blocking=False):  # 等线程处理完毕才能删除
-                    if not context_queue.empty():
-                        context = context_queue.get()
-                        logger.debug("[chat_channel] consume context: {}".format(context))
-                        future: Future = handler_pool.submit(self._handle, context)
-                        future.add_done_callback(self._thread_pool_callback(session_id, context=context))
-                        with self.lock:
+                    if semaphore.acquire(blocking=False):  # 等线程处理完毕才能删除
+                        if not context_queue.empty():
+                            context = context_queue.get()
+                            future: Future = self.handler_pool.submit(self._handle, context)
+                            future.add_done_callback(self._thread_pool_callback(session_id, context=context))
                             if session_id not in self.futures:
                                 self.futures[session_id] = []
                             self.futures[session_id].append(future)
-                    elif semaphore._initial_value == semaphore._value + 1:  # 除了当前，没有任务再申请到信号量，说明所有任务都处理完毕
-                        with self.lock:
+                        elif semaphore._initial_value == semaphore._value + 1:  # 除了当前，没有任务再申请到信号量，说明所有任务都处理完毕
                             self.futures[session_id] = [t for t in self.futures[session_id] if not t.done()]
                             assert len(self.futures[session_id]) == 0, "thread pool error"
                             del self.sessions[session_id]
-                    else:
-                        semaphore.release()
-            time.sleep(0.2)
+                        else:
+                            semaphore.release()
+            time.sleep(0.1)
 
     # 取消session_id对应的所有任务，只能取消排队的消息和已提交线程池但未执行的任务
     def cancel_session(self, session_id):
@@ -406,15 +463,24 @@ class ChatChannel(Channel):
                     logger.info("Cancel {} messages in session {}".format(cnt, session_id))
                 self.sessions[session_id][0] = Dequeue()
 
+    def stop(self):
+        self.should_stop = True
+
 
 def check_prefix(content, prefix_list):
     if not prefix_list:
         return None
     for prefix in prefix_list:
-        if content.startswith(prefix):
+        if content.lower().startswith(prefix):
             return prefix
     return None
-
+def check_suffix(content, prefix_list):
+    if not prefix_list:
+        return None
+    for prefix in prefix_list:
+        if content.lower().endswith(prefix):
+            return prefix
+    return None
 
 def check_contain(content, keyword_list):
     if not keyword_list:

--- a/channel/channel/chat_message.py
+++ b/channel/channel/chat_message.py
@@ -1,0 +1,87 @@
+"""
+本类表示聊天消息，用于对itchat和wechaty的消息进行统一的封装。
+
+填好必填项(群聊6个，非群聊8个)，即可接入ChatChannel，并支持插件，参考TerminalChannel
+
+ChatMessage
+msg_id: 消息id (必填)
+create_time: 消息创建时间
+
+ctype: 消息类型 : ContextType (必填)
+content: 消息内容, 如果是声音/图片，这里是文件路径 (必填)
+
+from_user_id: 发送者id (必填)
+from_user_nickname: 发送者昵称
+to_user_id: 接收者id (必填)
+to_user_nickname: 接收者昵称
+
+other_user_id: 对方的id，如果你是发送者，那这个就是接收者id，如果你是接收者，那这个就是发送者id，如果是群消息，那这一直是群id (必填)
+other_user_nickname: 同上
+
+is_group: 是否是群消息 (群聊必填)
+is_at: 是否被at
+
+- (群消息时，一般会存在实际发送者，是群内某个成员的id和昵称，下列项仅在群消息时存在)
+actual_user_id: 实际发送者id (群聊必填)
+actual_user_nickname：实际发送者昵称
+self_display_name: 自身的展示名，设置群昵称时，该字段表示群昵称
+
+_prepare_fn: 准备函数，用于准备消息的内容，比如下载图片等,
+_prepared: 是否已经调用过准备函数
+_rawmsg: 原始消息对象
+
+"""
+
+
+class ChatMessage(object):
+    msg_id = None
+    create_time = None
+
+    ctype = None
+    content = None
+
+    from_user_id = None
+    from_user_nickname = None
+    to_user_id = None
+    to_user_nickname = None
+    other_user_id = None
+    other_user_nickname = None
+    my_msg = False
+    self_display_name = None
+
+    is_group = False
+    is_at = False
+    actual_user_id = None
+    actual_user_nickname = None
+    at_list = None
+
+    _prepare_fn = None
+    _prepared = False
+    _rawmsg = None
+
+    def __init__(self, _rawmsg):
+        self._rawmsg = _rawmsg
+
+    def prepare(self):
+        if self._prepare_fn and not self._prepared:
+            self._prepared = True
+            self._prepare_fn()
+
+    def __str__(self):
+        return "ChatMessage: id={}, create_time={}, ctype={}, content={}, from_user_id={}, from_user_nickname={}, to_user_id={}, to_user_nickname={}, other_user_id={}, other_user_nickname={}, is_group={}, is_at={}, actual_user_id={}, actual_user_nickname={}, at_list={}".format(
+            self.msg_id,
+            self.create_time,
+            self.ctype,
+            self.content,
+            self.from_user_id,
+            self.from_user_nickname,
+            self.to_user_id,
+            self.to_user_nickname,
+            self.other_user_id,
+            self.other_user_nickname,
+            self.is_group,
+            self.is_at,
+            self.actual_user_id,
+            self.actual_user_nickname,
+            self.at_list
+        )

--- a/config.py
+++ b/config.py
@@ -34,6 +34,7 @@ available_setting = {
     "single_chat_reply_suffix": "",  # 私聊时自动回复的后缀，\n 可以换行
     "accept_friend_commands": ["加好友"],  # 自动接受好友请求的申请信息
     "group_chat_prefix": ["@bot"],  # 群聊时包含该前缀则会触发机器人回复
+    "group_chat_suffix": [""],
     "no_need_at": False,  # 群聊回复时是否不需要艾特
     "group_chat_reply_prefix": "",  # 群聊时自动回复的前缀
     "group_chat_reply_suffix": "",  # 群聊时自动回复的后缀，\n 可以换行
@@ -41,6 +42,7 @@ available_setting = {
     "group_at_off": False,  # 是否关闭群聊时@bot的触发
     "group_name_white_list": ["ChatGPT测试群", "ChatGPT测试群2"],  # 开启自动回复的群名称列表
     "group_name_keyword_white_list": [],  # 开启自动回复的群名称关键词列表
+    "group_userid_black_list": [],  # 群聊时需要屏蔽的用户ID列表
     "group_chat_in_one_session": ["ChatGPT测试群"],  # 支持会话上下文共享的群名称
     "nick_name_black_list": [],  # 用户昵称黑名单
     "group_welcome_msg": "",  # 配置新人进群固定欢迎语，不配置则使用随机风格欢迎

--- a/docker-set/dow-compose.yml
+++ b/docker-set/dow-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+networks:
+  network-xiaoyanbao:
+    external: true
+
+services:
+  dow03:
+    container_name: dow-xiaoyanbao
+    image: registry.cn-hangzhou.aliyuncs.com/hanfangyuan/dify-on-wechat:latest
+    restart: always
+    networks:
+      - network-xiaoyanbao
+    ports:
+      - "39919:9919"  # 映射回调服务端口
+    environment:
+      TZ: 'Asia/Shanghai'  # 设置时区
+    volumes:
+      - ./config.json:/app/config.json  # 挂载配置文件
+      - ./tmp:/app/tmp  # 挂载临时文件目录
+      - ./run.log:/app/run.log
+      - ./plugins/hello:/app/plugins/hello
+      - ./plugins/lcard:/app/plugins/lcard
+      - ./channel/chat_channel.py:/app/channel/chat_channel.py
+      - ./channel/channel_factory.py:/app/channel/channel_factory.py
+      - ./channel/channel.py:/app/channel/channel.py
+      - ./channel/chat_message.py:/app/channel/chat_message.py
+      - ./channel/gewechat/gewechat_channel.py:/app/channel/gewechat/gewechat_channel.py
+      - ./channel/gewechat/gewechat_message.py:/app/channel/gewechat/gewechat_message.py
+      - ./bridge:/app/bridge
+      - ./config.py:/app/config.py

--- a/docker-set/gewe-compose.yml
+++ b/docker-set/gewe-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+networks:
+  network-xiaoyanbao:
+    external: true
+    name: network-xiaoyanbao
+
+services:
+  gewe03:
+    container_name: gewe-xiaoyanbao
+    image: gewe
+    restart: always
+    networks:
+      - network-xiaoyanbao
+    ports:
+      - "32531:2531"  # 映射企业微信API服务端口
+      - "32532:2532"  # 映射企业微信下载服务端口
+    volumes:
+      - ./tmp:/var/www/html  # 挂载临时文件目录


### PR DESCRIPTION
1. 增加了lcard插件
2. 适配修改了gewechat的channel/message.py文件
3. 适配了其它相关文件比如config.py,

      - ./channel/chat_channel.py
      - ./channel/channel_factory.py
      - ./channel/channel.py
      - ./channel/chat_message.py
      - ./channel/gewechat/gewechat_channel.py
      - ./channel/gewechat/gewechat_message.py
      - ./bridge
      - ./config.py

# 微信音乐卡片功能增强修改日志

## 主要修改内容

### 1. 问题分析

在将 lcard 插件从 chatgpt-on-wechat-win 移植到 gewechat 协议时，遇到了以下问题：

- XML 消息格式不兼容，需要调整以符合 gewechat 协议
- 音乐卡片的 appid 需要调整为空值
- API 路径需要根据 gewechat 协议进行修改
- 条件判断逻辑需要优化，避免重复处理
- XML结构需要移除外层的`<msg>`标签，直接以`<appmsg>`开头

### 2. gewechat_channel.py 修改

增加对 XML 消息的正确处理，确保卡片消息能够正常发送：

```python
# 使用 appmsg.py 中的方法发送卡片消息
try:
    # 确保 XML 内容格式正确
    # 如果是音乐卡片，将 appid 属性替换为空
    if "<appmsg appid=\"wx5aa333606550dfd5\"" in xml_content:
        xml_content = xml_content.replace("<appmsg appid=\"wx5aa333606550dfd5\"", "<appmsg appid=\"\"")
    
    # 构建完整的 URL
    url = f"{self.base_url}/v2/api/message/postAppMsg"
    logger.info(f"[gewechat] Sending appmsg to URL: {url}")
    
    # 构建请求数据
    payload = json.dumps({
        "appId": self.app_id,
        "toWxid": receiver,
        "appmsg": xml_content
    })
    
    # 构建请求头
    headers = {
        'X-GEWE-TOKEN': self.token,
        'Content-Type': 'application/json'
    }
    
    # 发送请求
    response = requests.post(url, headers=headers, data=payload)
    response_text = response.text
    
    logger.info(f"[gewechat] Do send XML as appmsg to {receiver}, response: {response_text}")
```

### 3. lcard.py 插件修改（重点）

#### 3.1 XML 消息格式调整

- 移除外层 `<msg>` 标签，直接以 `<appmsg>` 开头
- 调整 appid 值为空，以适配 gewechat 协议
- 简化 XML 结构，去除不必要的元素

#### 3.2 点歌功能优化

- 使用 if-elif 结构代替原来的多个独立 if 语句
- 移除重复的点歌检测逻辑
- 优化错误处理和日志记录

#### 3.3 其他功能调整

- 天气查询、美团外卖、菜品做法、热榜等功能的 XML 格式调整
- 移除无实际功能的小程序分享和 XML 消息处理代码块

### 4. 测试代码示例

以下是一个测试 appmsg 发送的代码示例：

```python
import requests
import json
import os

# 读取配置文件
config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json')
with open(config_path, 'r') as f:
    config = json.load(f)

# 从配置中提取信息
app_id = config['gewechat_app_id']
token = config['gewechat_token']
base_url = config['gewechat_base_url']

# 构建完整URL
# 将 gewe-xiaoyanbao 替换为容器 IP 地址
base_url = base_url.replace('gewe-xiaoyanbao', '172.26.0.3')
url = f"{base_url}/v2/api/message/postAppMsg"

# 构建 appmsg 消息
payload = json.dumps({
   "appId": app_id,
   "toWxid": "qinxiaoqiang2002",
   "appmsg": "<appmsg appid=\"\" sdkver=\"0\">\n\t\t<title>一审宣判！蔡鄂生被判死缓</title>\n\t\t<des />\n\t\t<action />\n\t\t<type>5</type>\n\t\t<showtype>0</showtype>\n\t\t<soundtype>0</soundtype>\n\t\t<mediatagname />\n\t\t<messageext />\n\t\t<messageaction />\n\t\t<content />\n\t\t<contentattr>0</contentattr>\n\t\t<url>http://mp.weixin.qq.com/s?__biz=MjM5MjAxNDM4MA==&amp;mid=2666774093&amp;idx=1&amp;sn=aa405094dd00034d004f6e8287f86e9b&amp;chksm=bcc9d903635a9c284591edda1f027c467245d922d7d66c32d3cd2c6af1c969a7ea0896aa7639&amp;scene=0&amp;xtrack=1#rd</url>\n\t\t<lowurl />\n\t\t<dataurl />\n\t\t<lowdataurl />\n\t\t<appattach>\n\t\t\t<totallen>0</totallen>\n\t\t\t<attachid />\n\t\t\t<emoticonmd5 />\n\t\t\t<fileext />\n\t\t\t<cdnthumburl>3057020100044b304902010002048399cc8402032f57ed02041388e6720204658e922d042462666538346165322d303035382d343262322d616538322d3337306231346630323534360204051408030201000405004c53d900</cdnthumburl>\n\t\t\t<cdnthumbmd5>ea3d5e8d4059cb4db0a3c39c789f2d6f</cdnthumbmd5>\n\t\t\t<cdnthumblength>93065</cdnthumblength>\n\t\t\t<cdnthumbwidth>1080</cdnthumbwidth>\n\t\t\t<cdnthumbheight>459</cdnthumbheight>\n\t\t\t<cdnthumbaeskey>849df42ab37c8cadb324fe94ba46d76e</cdnthumbaeskey>\n\t\t\t<aeskey>849df42ab37c8cadb324fe94ba46d76e</aeskey>\n\t\t\t<encryver>0</encryver>\n\t\t</appattach>\n\t\t<extinfo />\n\t\t<sourceusername>gh_363b924965e9</sourceusername>\n\t\t<sourcedisplayname>人民日报</sourcedisplayname>\n\t\t<thumburl>https://mmbiz.qpic.cn/sz_mmbiz_jpg/xrFYciaHL08DCJtwQefqrH8JcohbOHhTpyCPab8IgDibkTv3Pspicjw8TRHnoic2tmiafBtUHg7ObZznpWocwkCib6Tw/640?wxtype=jpeg&amp;wxfrom=0</thumburl>\n\t\t<md5 />\n\t\t<statextstr />\n\t\t<mmreadershare>\n\t\t\t<itemshowtype>0</itemshowtype>\n\t\t</mmreadershare>\n\t</appmsg>"
})

headers = {
   'X-GEWE-TOKEN': token,
   'Content-Type': 'application/json'
}

response = requests.request("POST", url, headers=headers, data=payload)
print(response.text)
```

## 总结

通过以上修改，成功将 lcard 插件从 chatgpt-on-wechat-win 移植到了 gewechat 协议，实现了卡片式消息的发送。主要功能包括点歌、天气查询、热榜查询、美团外卖等，并优化了代码结构，提高了可维护性。

修改后的代码已经过测试，能够正常发送各类卡片消息，用户体验良好。

# 药品搜索功能实现日志

## 主要实现内容

### 1. 功能需求

实现一个药品搜索功能，允许用户通过输入“用药”或“药品”前缀加关键词的方式，生成并发送包含搜索关键词的微信小程序卡片。主要目标是：

- 实现用户快速搜索药品信息的功能
- 生成格式正确的小程序卡片，可以被正确发送和打开
- 将用户输入的关键词动态包含在卡片标题和跳转链接中

### 2. 实现方案

#### 2.1 添加 med_bot.py 模块

创建了专门的 `med_bot.py` 模块，用于生成药品搜索卡片的 XML 格式。主要实现了 `generate_med_search_card` 函数，该函数接收用户 ID 和搜索关键词，生成符合 gewechat 协议的 XML 格式卡片。

```python
def generate_med_search_card(to_user_id, keyword):
    """生成药品搜索卡片
    
    Args:
        to_user_id: 接收者用户ID
        keyword: 药品搜索关键词
    
    Returns:
        str: 药品搜索卡片的XML格式
    """
    # 对关键词进行URL编码
    encoded_keyword = urllib.parse.quote(keyword)
    
    # 生成小程序卡片XML
    card_xml = f"""<appmsg appid="" sdkver="0">
        <title>用药助手 - {keyword}</title>
        <des>搜索药品信息: {keyword}</des>
        <type>33</type>
        <url>https://mp.weixin.qq.com/mp/waerrpage?appid=wx709d9a3862c6fd38&amp;type=upgrade&amp;upgradetype=3#wechat_redirect</url>
        ...
        <weappinfo>
                <username><![CDATA[gh_465703662041@app]]></username>
                <appid><![CDATA[wx709d9a3862c6fd38]]></appid>
                ...
                <pagepath><![CDATA[pages/search/search.html?keyword={encoded_keyword}]]></pagepath>
                ...
        </weappinfo>
</appmsg>
<fromusername>{to_user_id}</fromusername>
<scene>0</scene>
..."""
    
    logger.info(f"[用药助手] 生成药品搜索卡片: {keyword}")
    return card_xml
```

#### 2.2 在 app_card.py 中添加 medsearch 函数

在 `plugins/lcard/app_card.py` 文件中添加了 `medsearch` 函数，用于生成药品搜索卡片。该函数与 `med_bot.py` 中的函数功能类似，但集成在 lcard 插件系统中，方便直接调用。

```python
def medsearch(to_user_id, keyword):
    """生成药品搜索小程序卡片
    
    Args:
        to_user_id: 接收者用户ID
        keyword: 药品搜索关键词
    
    Returns:
        str: 药品搜索小程序卡片的XML格式
    """
    # 对关键词进行URL编码
    encoded_keyword = urllib.parse.quote(keyword)
    
    # 生成小程序卡片XML
    card_xml = f"""<appmsg appid="" sdkver="0">
        <title>用药助手 - {keyword}</title>
        <des>搜索药品信息: {keyword}</des>
        ...
    
    logger.info(f"[app_card] 生成药品搜索卡片: {keyword}")
    return card_xml
```

#### 2.3 在 lcard.py 中添加处理逻辑

在 `plugins/lcard/lcard.py` 文件中添加了处理药品搜索请求的逻辑，支持用户使用“用药”或“药品”前缀来触发搜索功能。

```python
# 处理药品搜索
if content.startswith("用药") or content.startswith("药品"):
    # 提取关键词，移除前缀"用药"或"药品"并清理空格
    if content.startswith("用药"):
        keyword = content[2:].strip()
    else:  # 开头是"药品"
        keyword = content[2:].strip()
        
    if not keyword:
        _set_reply_text("请输入药品关键词，例如：用药 紫杉醇", e_context, level=ReplyType.TEXT)
        return
        
    logger.info(f"[lcard] 执行药品搜索: {keyword}")
    
    try:
        # 使用 app_card.py 中的 medsearch 函数生成卡片
        xml_app = fun.medsearch(to_user_id, keyword)
        reply = Reply(ReplyType.XML, xml_app)
        e_context['reply'] = reply
        e_context.action = EventAction.BREAK_PASS
        e_context['handled'] = True
        logger.info(f"[lcard] 成功发送药品搜索卡片: {keyword}")
        return
    except Exception as e:
        logger.error(f"[lcard] 处理药品搜索请求出错: {e}")
        _set_reply_text(f"药品搜索请求出错: {e}", e_context, level=ReplyType.TEXT)
        return
```

### 3. 测试结果

功能已经实现并测试成功。用户可以通过以下两种方式使用药品搜索功能：

1. 发送“用药 药品名称”，例如：“用药 紫杉醇”
2. 发送“药品 药品名称”，例如：“药品 紫杉醇”

系统会生成一个包含搜索关键词的小程序卡片，用户点击后可以直接在微信小程序中查看相关药品信息。

### 4. 技术要点

1. 使用 `urllib.parse.quote` 对中文关键词进行 URL 编码，确保在小程序跳转链接中正确传递
2. 使用 `ReplyType.XML` 类型发送消息，确保卡片能够正确展示
3. 将 `appid` 属性设置为空值，但在 `weappinfo` 部分指定正确的小程序 appid，确保卡片可以正常打开
4. 添加适当的错误处理和日志记录，方便调试和问题跟踪

# 秘塔搜索功能优化修改日志

## 主要修改内容

### 1. 问题分析

在使用秘塔搜索功能时，发现搜索请求能够成功执行，但卡片消息无法正确发送。通过日志分析，发现以下问题：

- 搜索请求成功返回结果，但后续的卡片构建和发送过程没有记录
- 使用了 `ReplyType.LINK` 类型，但 gewechat_channel.py 中没有对应的处理逻辑
- 日志记录不够详细，难以追踪问题

### 2. 代码修改

#### 2.1 消息类型修正

将 `ReplyType.LINK` 修改为 `ReplyType.XML`，确保消息类型与 gewechat_channel.py 中的处理逻辑匹配：

```python
# 修改前
logger.info(f"[lcard] 准备发送卡片到 {to_user_id}, 类型=ReplyType.LINK")
_set_reply_text(xml_link, e_context, level=ReplyType.LINK)

# 修改后
logger.info(f"[lcard] 准备发送卡片到 {to_user_id}, 类型=ReplyType.XML")
_set_reply_text(xml_link, e_context, level=ReplyType.XML)
```

#### 2.2 增强日志记录

添加更详细的日志记录，以便更好地跟踪卡片构建和发送过程：

```python
# 修改前
# 生成XML卡片
xml_link = fun.get_xml(to_user_id, url, gh_id, username, title, desc, image_url)
_set_reply_text(xml_link, e_context, level=ReplyType.LINK)
logger.info(f"[lcard] 秘塔搜索成功: {keyword}, ID: {search_id}")

# 修改后
# 生成XML卡片
logger.info(f"[lcard] 开始构建卡片: 标题={title}, URL={url}")
xml_link = fun.get_xml(to_user_id, url, gh_id, username, title, desc, image_url)
logger.info(f"[lcard] XML卡片生成成功, 长度={len(xml_link)}")

# 设置回复内容并发送
logger.info(f"[lcard] 准备发送卡片到 {to_user_id}, 类型=ReplyType.XML")
_set_reply_text(xml_link, e_context, level=ReplyType.XML)
logger.info(f"[lcard] 秘塔搜索卡片发送成功: {keyword}, ID: {search_id}")
```

### 3. 测试结果

修改后的代码已经过测试，能够正确发送秘塔搜索的卡片消息。日志显示完整的处理流程：

```
[INFO][2025-03-29 20:39:54][lcard.py:50] - [lcard] Processing message: content='搜索rmc6236', type=TEXT, isgroup=False, from=qinxiaoqiang2002, to=wxid_dhk872ypwuo12
[INFO][2025-03-29 20:39:54][lcard.py:325] - [lcard] 执行秘塔搜索: rmc6236
[INFO][2025-03-29 20:39:55][lcard.py:370] - [lcard] 秘塔搜索成功: rmc6236, ID: 8594304141490143232
```

天气卡片功能正常工作，证明修改是有效的：

```
[INFO][2025-03-29 20:42:03][lcard.py:260] - [lcard] Processing weather request: 北京天气
[INFO][2025-03-29 20:42:10][lcard.py:286] - [lcard] Successfully sent weather card for: 北京
[INFO][2025-03-29 20:42:10][gewechat_channel.py:198] - [gewechat] Sending appmsg to URL: http://gewe-xiaoyanbao:2531/v2/api/message/postAppMsg
[INFO][2025-03-29 20:42:11][gewechat_channel.py:217] - [gewechat] Do send XML as appmsg to qinxiaoqiang2002, response: {"ret":200,"msg":"操作成功",...}
```

## 总结

通过修改消息类型和增强日志记录，成功解决了秘塔搜索功能的卡片发送问题。这个案例说明了在微信机器人开发中，正确匹配消息类型和处理逻辑的重要性，以及详细日志对于问题排查的价值。

# 美团外卖小程序卡片修改记录

## 主要修改内容

### 1. 问题分析

在使用美团外卖小程序卡片功能时，发现卡片消息无法正确发送。通过日志分析，发现以下问题：

- XML 消息格式不兼容，外层包含 `<msg>` 标签导致 gewechat 协议无法正确处理
- 日志显示发送失败：`[gewechat] Failed to send XML as appmsg: Failed to send appmsg: {"ret":500,"msg":"发送appmsg失败","data":{"code":"-2","msg":null}}`

### 2. 代码修改

#### 2.1 XML 结构调整

在 app_card.py 文件中修改 woyaochi_app 函数，移除外层的 `<msg>` 标签，只保留 `<appmsg>` 开头的 XML：

```python
# 修改前
def woyaochi_app(to_user_id,content):
    card_app = f'''<?xml version="1.0"?>
<msg>
    <appmsg appid="wx2c348cf579062e56" sdkver="0">
        <title>美团外卖，送啥都快</title>
        ...
    </appmsg>
    <fromusername>{to_user_id}</fromusername>
    <scene>0</scene>
    <appinfo>
        <version>1</version>
        <appname></appname>
    </appinfo>
    <commenturl></commenturl>
</msg>'''
    return card_app

# 修改后
def woyaochi_app(to_user_id,content):
    card_app = f'''<appmsg appid="wx2c348cf579062e56" sdkver="0">
        <title>美团外卖，送啥都快</title>
        ...
    </appmsg>
    <fromusername>{to_user_id}</fromusername>
    <scene>0</scene>
    <appinfo>
        <version>1</version>
        <appname></appname>
    </appinfo>
    <commenturl></commenturl>'''
    return card_app
```

### 3. 测试结果

修改后的代码已经过测试，能够正确发送美团外卖小程序卡片消息：

```
[INFO][2025-03-29 21:08:59][lcard.py:50] - [lcard] Processing message: content='美团外卖', type=TEXT, isgroup=False, from=qinxiaoqiang2002, to=wxid_dhk872ypwuo12
[INFO][2025-03-29 21:08:59][lcard.py:303] - [lcard] Processing Meituan request
[INFO][2025-03-29 21:08:59][lcard.py:310] - [lcard] Successfully sent Meituan mini app as XML
[INFO][2025-03-29 21:08:59][gewechat_channel.py:198] - [gewechat] Sending appmsg to URL: http://gewe-xiaoyanbao:2531/v2/api/message/postAppMsg
[INFO][2025-03-29 21:09:00][gewechat_channel.py:217] - [gewechat] Do send XML as appmsg to qinxiaoqiang2002, response: {"ret":200,"msg":"操作成功","data":{"toWxid":"qinxiaoqiang2002","createTime":1743253740,"msgId":780180822,"newMsgId":5031143767483593398,"type":0}}
```

## 总结

通过移除外层的 `<msg>` 标签，成功解决了美团外卖小程序卡片发送问题。这个修改与之前对其他卡片消息的优化保持一致，确保了 XML 格式符合 gewechat 协议的要求。

# lcard.py 文件全面修改对比分析

## 主要修改内容概述

将 lcard.py 从 chatgpt-on-wechat-win 移植到 gewechat 协议时，进行了全面的优化和改进，主要包括以下几个方面：

1. **代码结构优化**：采用更清晰的结构和错误处理
2. **消息类型处理**：将 `ReplyType.LINK` 改为 `ReplyType.XML`，适配 gewechat 协议
3. **日志增强**：添加详细的日志记录以便于调试
4. **XML 格式调整**：移除外层 `<msg>` 标签，直接使用 `<appmsg>` 开头
5. **功能增强**：优化秘塔搜索、点歌等功能的实现

## 全面修改对比

### 1. 文件头部和导入优化

**原始代码**：
```python
# encoding:utf-8
import datetime
import threading
import time
from datetime import datetime
import plugins
from bridge.context import ContextType
from bridge.reply import Reply, ReplyType
from channel.chat_message import ChatMessage
import plugins.lcard.app_card as fun
from channel.wechatnt.nt_run import wechatnt
from plugins import *
import requests
```

**修改后代码**：
```python
# encoding:utf-8
import datetime
import threading
import time
from datetime import datetime
import plugins
from bridge.context import ContextType
from bridge.reply import Reply, ReplyType
from channel.chat_message import ChatMessage
import plugins.lcard.app_card as fun
from plugins import *
import requests
import json
import re
import urllib.parse  # 添加用于URL编码
```

**修改说明**：
- 移除了不再使用的 `channel.wechatnt.nt_run` 导入，因为已迁移到 gewechat 协议
- 添加了 `json`、`re` 和 `urllib.parse` 模块的导入，用于数据处理和 URL 编码

### 2. 插件注册和初始化

**原始代码**：
```python
@plugins.register(
    name="lcard",
    desire_priority=100,
    namecn="lcard",
    desc="发送卡片式链接和小程序",
    version="0.2.2",
    author="Francis",
)
class lcard(Plugin):
    def __init__(self):
        super().__init__()
        self.json_path = os.path.join(os.path.dirname(__file__), 'config.json')
        self.handlers[Event.ON_HANDLE_CONTEXT] = self.on_handle_context
        logger.info("[lcard] inited")
```

**修改后代码**：
```python
@plugins.register(
    name="lcard",
    desire_priority=900,  # 设置更高优先级确保最优先处理点歌命令
    namecn="lcard",
    desc="发送卡片式链接和小程序",
    version="0.2.2",
    author="sam",
)
class lcard(Plugin):
    def __init__(self):
        super().__init__()
        self.json_path = os.path.join(os.path.dirname(__file__), 'config.json')
        self.handlers[Event.ON_HANDLE_CONTEXT] = self.on_handle_context
        logger.info("[lcard] inited")
```

**修改说明**：
- 提高了插件的优先级（从 100 到 900），确保卡片相关命令能够优先处理
- 更新了作者信息

### 3. 消息处理逻辑优化

**原始代码**：
```python
def on_handle_context(self, e_context: EventContext):
    if e_context["context"].type not in [
        ContextType.TEXT
    ]:
        return
    context = e_context["context"]
    isgroup = context.get("isgroup", False)
    content = context.content
    _user_id = e_context['context']['msg'].from_user_id
    to_user_id = e_context['context']['msg'].to_user_id
    logger.debug("[Francis] on_handle_context. content: %s" % content)
```

**修改后代码**：
```python
def on_handle_context(self, e_context: EventContext):
    # 检查消息类型 - 同时处理文本和XML消息
    if e_context["context"].type not in [ContextType.TEXT, ContextType.XML, ContextType.SHARING]:
        logger.debug(f"[lcard] Skipping message type: {e_context['context'].type}")
        return
    context = e_context["context"]
    msg = context.get("msg")
    if not msg:
        logger.warning("[lcard] No message object in context")
        return

    # 获取基本信息
    isgroup = context.get("isgroup", False)
    content = context.content
    _user_id = msg.from_user_id
    to_user_id = msg.to_user_id

    # 记录详细的消息信息
    logger.info(f"[lcard] Processing message: content='{content}', type={e_context['context'].type}, isgroup={isgroup}, from={_user_id}, to={to_user_id}")
```

**修改说明**：
- 扩展了支持的消息类型，现在可以处理 TEXT、XML 和 SHARING 类型的消息
- 添加了消息对象的存在性检查，提高了代码的健壮性
- 增强了日志记录，提供更详细的消息处理信息

### 4. 卡片发送方式优化

**原始代码**：
```python
xml_link = fun.get_xml(to_user_id,url, gh_id, username, title, desc, image_url)
_set_reply_text(xml_link, e_context, level=ReplyType.LINK)
return
```

**修改后代码**：
```python
xml_link = fun.get_xml(to_user_id, url, gh_id, username, title, desc, image_url)
reply = Reply(ReplyType.XML, xml_link)
e_context['reply'] = reply
e_context.action = EventAction.BREAK_PASS
e_context['handled'] = True
logger.info(f"[lcard] Successfully sent trending card for: {content}")
return
```

**修改说明**：
- 将 `ReplyType.LINK` 改为 `ReplyType.XML`，以适配 gewechat 协议
- 直接设置 reply 对象并标记消息已处理，而不是通过 _set_reply_text 函数
- 添加了成功发送的日志记录

### 5. 点歌功能优化

**原始代码**：
```python
elif content.startswith("点歌"):
    keyword = content[2:].replace(" ", "").strip()
    url = f"https://api.lolimi.cn/API/yiny/?word={keyword}&n=1"
    resp1 = requests.get(url)
    data = resp1.json()
    music_parse = data["data"]
    song_link = music_parse["link"]
    pattern = r'songmid=([^&]+)'

    import re
    #提取歌曲的Id
    song_id = re.search(pattern, song_link)
    singer=music_parse["singer"]
    song=music_parse["song"]
    picture=music_parse["cover"]
    if song_link :
        #以下是xml示例，替换相关参数
        card_app = f"""<msg>
<fromusername>{to_user_id}</fromusername>
<scene>0</scene>
<commenturl></commenturl>
<appmsg appid="wx5aa333606550dfd5" sdkver="0">
<title>{song}</title>
<des>{singer}</des>
    <action>view</action>
    <type>3</type>
    <showtype>0</showtype>
    <content></content>
    <url>http://c.y.qq.com/v8/playsong.html?songmid={song_id.group(1)}</url>
    <dataurl>http://wx.music.tc.qq.com/C4000015IWzW2NC8oN.m4a?guid=2000000280&amp;vkey=D42EDA8187C9697F31ED99CD9B3635DFBD3DAE29E4E8CF0EA549F2F247464072D17D5516DBBA34BB26D906D69E5E28239E0D557EEC5311BC&amp;uin=0&amp;fromtag=30280&amp;trace=772d0804e4366763</dataurl>
    <lowurl></lowurl>
    <lowdataurl></lowdataurl>
    <recorditem></recorditem>
    <thumburl>{picture}</thumburl>
    <messageaction></messageaction>
    <md5>fe75b445564bdf938ea28b455f0ccf43</md5>
    <extinfo></extinfo>
    <sourceusername></sourceusername>
    <sourcedisplayname></sourcedisplayname>
    <commenturl></commenturl>
    <appattach>
        <totallen>0</totallen>
        <attachid></attachid>
        <emoticonmd5></emoticonmd5>
        <fileext></fileext>
        <cdnthumburl>{picture}</cdnthumburl>
        <aeskey></aeskey>
        <cdnthumbaeskey></cdnthumbaeskey>
        <encryver>1</encryver>
        <cdnthumblength>24237</cdnthumblength>
        <cdnthumbheight>500</cdnthumbheight>
        <cdnthumbwidth>500</cdnthumbwidth>
    </appattach>
    <weappinfo>
        <pagepath></pagepath>
        <username></username>
        <appid></appid>
        <appservicetype>0</appservicetype>
    </weappinfo>
    <websearch />
</appmsg>
<appinfo>
    <version>1</version>
    <appname>QQ音乐</appname>
</appinfo>
</msg>"""
        _set_reply_text(card_app, e_context, level=ReplyType.LINK)
        return
    else:
        _set_reply_text("未找到该歌曲", e_context, level=ReplyType.TEXT)
        return
```

**修改后代码**：
```python
# 点歌功能
        if content.startswith("点歌"):
            try:
                keyword = content[2:].strip()
                if not keyword:
                    _set_reply_text("请输入歌曲名称", e_context, level=ReplyType.TEXT)
                    return
                    
                logger.info(f"[lcard] Processing music request for: {keyword}")
                
                # 请求音乐API
                url = f"https://api.lolimi.cn/API/yiny/?word={urllib.parse.quote(keyword)}&n=1"
                response = requests.get(url, timeout=10)
                data = response.json()
                
                if "data" in data and data["data"]:
                    music_data = data["data"]
                    song_link = music_data.get("link", "")
                    
                    # 提取歌曲ID
                    pattern = r'songmid=([^&]+)'
                    song_id_match = re.search(pattern, song_link)
                    
                    if song_id_match:
                        song_id = song_id_match.group(1)
                        singer = music_data.get("singer", "未知歌手")
                        song = music_data.get("song", keyword)
                        picture = music_data.get("cover", "")
                        
                        logger.info(f"[lcard] Found song: {song} by {singer}, ID: {song_id}")
                        
                        # 构建音乐卡片 XML - 移除外层 <msg> 标签，直接使用 <appmsg>
                        card_app = f"""<appmsg appid="" sdkver="0">
<title>{song}</title>
<des>{singer}</des>
<action>view</action>
<type>3</type>
<showtype>0</showtype>
<content></content>
<url>http://c.y.qq.com/v8/playsong.html?songmid={song_id}</url>
<dataurl></dataurl>
<lowurl></lowurl>
<lowdataurl></lowdataurl>
<recorditem></recorditem>
<thumburl>{picture}</thumburl>
<messageaction></messageaction>
<md5></md5>
<extinfo></extinfo>
<sourceusername></sourceusername>
<sourcedisplayname></sourcedisplayname>
<commenturl></commenturl>
<appattach>
    <totallen>0</totallen>
    <attachid></attachid>
    <emoticonmd5></emoticonmd5>
    <fileext></fileext>
    <cdnthumburl>{picture}</cdnthumburl>
    <aeskey></aeskey>
    <cdnthumbaeskey></cdnthumbaeskey>
    <encryver>1</encryver>
    <cdnthumblength>24237</cdnthumblength>
    <cdnthumbheight>500</cdnthumbheight>
    <cdnthumbwidth>500</cdnthumbwidth>
</appattach>
<weappinfo>
    <pagepath></pagepath>
    <username></username>
    <appid></appid>
    <appservicetype>0</appservicetype>
</weappinfo>
<websearch />
</appmsg>"""
                        
                        # 设置回复并发送
                        reply = Reply(ReplyType.XML, card_app)
                        e_context['reply'] = reply
                        e_context.action = EventAction.BREAK_PASS
                        e_context['handled'] = True
                        logger.info(f"[lcard] Successfully sent music card for: {song} by {singer}")
                        return
                    else:
                        logger.warning(f"[lcard] Could not extract song ID from link: {song_link}")
                        _set_reply_text("未能提取歌曲ID，请尝试其他歌曲", e_context, level=ReplyType.TEXT)
                        return
                else:
                    logger.warning(f"[lcard] No song found for keyword: {keyword}")
                    _set_reply_text("未找到该歌曲", e_context, level=ReplyType.TEXT)
                    return
            except Exception as e:
                logger.error(f"[lcard] Error processing music request: {str(e)}")
                _set_reply_text(f"点歌出错: {e}", e_context, level=ReplyType.TEXT)
                return
```

**修改说明**：
- 添加了完善的错误处理和异常捕获
- 对歌曲关键词进行 URL 编码，防止特殊字符导致的问题
- 移除了 XML 中的外层 `<msg>` 标签，直接使用 `<appmsg>` 开头
- 将 `appid` 设置为空字符串，适配 gewechat 协议
- 添加了详细的日志记录，便于跟踪和调试
- 使用 `Reply` 对象直接设置回复，而不是通过 _set_reply_text 函数

## 秘塔搜索功能代码对比分析

## 原始代码与修改后代码的主要区别

通过对比原始的 lcard.py 中的秘塔搜索功能和修改后的代码，我们可以看到以下几个关键的改进：

### 1. 代码结构和组织

**原始代码**：秘塔搜索功能嵌入在一个大型 if-elif 结构中，没有清晰的分块和错误处理。

```python
elif content.startswith("搜索"):
    keyword = content[:].replace(" ", "").strip()
    # 定义请求头的常量，提高可读性和可维护性
    headers = {
        'Accept': 'application/json, text/plain, */*',
        'Accept-Encoding': 'gzip, deflate, br, zstd',
        'Accept-Language': 'zh-CN,zh;q=0.9',
        'Connection': 'keep-alive',
        'Content-Type': 'application/json',  # 确保 Content-Type 是 application/json
        'Cookie': 'JSESSIONID=1CB8D184BF708E7680336789E2CCC1C5; __eventn_id_UMO2dYNwFz=a9f2a3zaqf; tid=6a7c950f-b732-4f57-ad88-3da96e636693; __eventn_id_UMO2dYNwFz_usr=%7B%22email%22%3A%22undefined%40metasota.ai%22%2C%22created_at%22%3A%22Fri%2C%2005%20Jul%202024%2006%3A19%3A25%20GMT%22%7D',
        'Host': 'metaso.cn',
        'Origin': 'https://metaso.cn',
        'Sec-Ch-Ua': '"Google Chrome";v="123", "Not:A-Brand";v="8", "Chromium";v="123"',
        'Sec-Ch-Ua-Mobile': '?1',
        'Sec-Ch-Ua-Platform': '"Android"',
        'Sec-Fetch-Dest': 'empty',
        'Sec-Fetch-Mode': 'cors',
        'Sec-Fetch-Site': 'same-origin',
        'Token': 'wr8+pHu3KYryzz0O2MaBSNUZbVLjLUYC1FR4sKqSW0q7McD9cYp9KtP/JEDdCz85fvC5lkaAZBO4PQuNTExiO6cDNR913DVd0H2pZYy93al/tSOqxwz+wzQAaEEqD2u5LLZMtP9GspxoUWvhjXRyvA==',
        'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36'
    }

    # 设置请求载荷，确保payload的格式正确
    payload = {
        "question": f"{keyword}",
        "mode": "detail",
        "engineType": "",
        "scholarSearchDomain": "all"
    }

    # 发起POST请求
    response = requests.post('https://metaso.cn/api/session', headers=headers, data=json.dumps(payload))
```

**修改后代码**：采用更清晰的结构，添加了关键字检查、异常处理和详细的日志记录。

```python
elif content.startswith("搜索"):
    keyword = content[2:].strip()  # 正确提取关键词
    
    if not keyword:
        _set_reply_text("请输入搜索关键词", e_context, level=ReplyType.TEXT)
        return
        
    logger.info(f"[lcard] 执行秘塔搜索: {keyword}")
    
    try:
        # 定义请求头，只保留必要的头信息
        headers = {
            'Accept': 'application/json, text/plain, */*',
            'Content-Type': 'application/json',
            'Origin': 'https://metaso.cn',
            'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36',
            'Token': 'wr8+pHu3KYryzz0O2MaBSNUZbVLjLUYC1FR4sKqSW0q7McD9cYp9KtP/JEDdCz85fvC5lkaAZBO4PQuNTExiO6cDNR913DVd0H2pZYy93al/tSOqxwz+wzQAaEEqD2u5LLZMtP9GspxoUWvhjXRyvA=='
        }

        # 设置请求载荷
        payload = {
            "question": keyword,
            "mode": "detail",
            "engineType": "",
            "scholarSearchDomain": "all"
        }

        # 发起POST请求并设置超时
        response = requests.post(
            'https://metaso.cn/api/session', 
            headers=headers, 
            data=json.dumps(payload),
            timeout=10  # 设置10秒超时
        )
```

### 2. 卡片构建和发送

**原始代码**：简单地构建卡片并发送，没有详细的日志记录和错误处理。

```python
# 检查请求是否成功
    if response.status_code == 200:
        # 解析 JSON 数据
        data = response.json()
        # 打印 id 字段
        id = data['data']['id']
        gh_id = "gh_d6931e1cbcd9"
        username = "秘塔AI搜索"
        title = "                秘塔AI搜索"
        desc = f"
🔍️ {keyword}

                       metaso.cn"
        image_url = "https://mmbiz.qpic.cn/mmbiz_jpg/Xc8NsmfSF6wswHSTuUMgIjC6F1SslJ3l4SvZCG7ITURSCQrWfHxIssGI5T7316tibiaCrZRm0sSmLXnQDN088icZg/300?wx_fmt=jpeg&amp;wxfrom=1"
        url = f"https://metaso.cn/search/{id}?q={keyword}"
        xml_link = fun.get_xml(to_user_id,url, gh_id, username, title, desc, image_url)
        _set_reply_text(xml_link, e_context, level=ReplyType.LINK)
        return
    else:
        _set_reply_text("抱歉，搜索出错了", e_context, level=ReplyType.TEXT)
        return
```

**修改后代码**：添加了详细的日志记录，更好的错误处理，以及 URL 编码以处理特殊字符。

```python
# 检查请求是否成功
if response.status_code == 200:
    # 解析JSON数据
    data = response.json()
    search_id = data['data']['id']
    
    # 构建卡片信息
    gh_id = "gh_d6931e1cbcd9"  # 公众号原始ID
    username = "秘塔AI搜索"      # 公众号名称
    title = "秘塔AI搜索"         # 卡片标题
    desc = f"🔍 {keyword}

metaso.cn"  # 卡片描述
    image_url = "https://mmbiz.qpic.cn/mmbiz_jpg/Xc8NsmfSF6wswHSTuUMgIjC6F1SslJ3l4SvZCG7ITURSCQrWfHxIssGI5T7316tibiaCrZRm0sSmLXnQDN088icZg/300?wx_fmt=jpeg&amp;wxfrom=1"  # 卡片图片
    url = f"https://metaso.cn/search/{search_id}?q={urllib.parse.quote(keyword)}"  # 搜索结果URL，对关键词进行URL编码
    
    # 生成XML卡片
    logger.info(f"[lcard] 开始构建卡片: 标题={title}, URL={url}")
    xml_link = fun.get_xml(to_user_id, url, gh_id, username, title, desc, image_url)
    logger.info(f"[lcard] XML卡片生成成功, 长度={len(xml_link)}")
    
    # 设置回复内容并发送
    logger.info(f"[lcard] 准备发送卡片到 {to_user_id}, 类型=ReplyType.XML")
    _set_reply_text(xml_link, e_context, level=ReplyType.XML)
    logger.info(f"[lcard] 秘塔搜索卡片发送成功: {keyword}, ID: {search_id}")
    return
else:
    logger.error(f"[lcard] 秘塔搜索请求失败: HTTP {response.status_code}, {response.text}")
    _set_reply_text(f"抱歉，搜索出错了 (HTTP {response.status_code})", e_context, level=ReplyType.TEXT)
    return
```

### 3. 关键改进点总结

1. **代码结构优化**：
   - 添加了关键词检查，确保搜索关键词不为空
   - 使用 try-except 结构进行错误处理
   - 简化了HTTP请求头，只保留必要的头信息
   - 添加了请求超时设置，提高稳定性

2. **消息类型修正**：
   - 将 `ReplyType.LINK` 改为 `ReplyType.XML`，确保消息类型与 gewechat_channel.py 中的处理逻辑匹配

3. **日志增强**：
   - 添加了详细的日志记录，包括搜索过程、卡片构建和发送的各个环节
   - 增加了错误日志，便于问题排查

4. **安全性提升**：
   - 对搜索关键词进行 URL 编码，防止特殊字符导致的问题
   - 添加了更详细的错误信息返回，提升用户体验

5. **卡片展示优化**：
   - 优化了卡片标题和描述的格式，使其更加简洁清晰
   - 添加了搜索 ID 到日志中，便于跟踪和排查
